### PR TITLE
feat: email support with compose, outbox, and sent views

### DIFF
--- a/teamshifts/apps.py
+++ b/teamshifts/apps.py
@@ -23,3 +23,4 @@ class TeamShiftsApp(PluginConfig):
 
     def ready(self):
         from . import signals  # NOQA
+        from . import tasks  # NOQA

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -3,14 +3,17 @@ from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 from django_scopes import scopes_disabled
 from eventyay.control.forms import SplitDateTimeField, SplitDateTimePickerWidget
+from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 
 from .models import (
     CFM_BUILTIN_FIELD_KEYS,
+    ApplicationStatus,
     AskChoices,
     CallForTeamMembers,
     QuestionVariant,
     TeamApplicationQuestion,
     TeamRole,
+    TeamShiftsEmailQueue,
     normalize_field_order,
 )
 
@@ -348,6 +351,81 @@ class EmailTemplateForm(forms.ModelForm):
                 self.fields[field_name].widget.enabled_locales = locales
 
 
+class EmailComposeForm(forms.Form):
+    def __init__(self, *args, event=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._event = event
+        locales = list(event.settings.get("locales") or [event.settings.locale])
+
+        self.fields["subject"] = I18nFormField(
+            label=_("Subject"),
+            widget=I18nTextInput,
+            required=True,
+            locales=locales,
+        )
+        self.fields["message"] = I18nFormField(
+            label=_("Message"),
+            widget=I18nTextarea,
+            required=True,
+            locales=locales,
+            widget_kwargs={"attrs": {"rows": 10}},
+        )
+
+        with scopes_disabled():
+            role_qs = TeamRole.objects.filter(event=event)
+        self.fields["role"] = forms.ModelChoiceField(
+            queryset=role_qs,
+            required=False,
+            empty_label=_("All roles"),
+            label=_("Send to role"),
+            widget=forms.Select(attrs={"class": "form-control"}),
+        )
+
+        self.fields["status"] = forms.ChoiceField(
+            choices=[("", _("All statuses"))] + list(ApplicationStatus.choices),
+            required=False,
+            initial=ApplicationStatus.ACCEPTED,
+            label=_("Send to applications with status"),
+            widget=forms.Select(attrs={"class": "form-control"}),
+        )
+
+        self.fields["send_after"] = forms.DateTimeField(
+            required=False,
+            label=_("Schedule for later"),
+            help_text=_("Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time."),
+            widget=forms.DateTimeInput(
+                attrs={"class": "form-control", "type": "datetime-local"},
+                format="%Y-%m-%dT%H:%M",
+            ),
+            input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
+        )
+
+
+class EmailQueueEditForm(forms.ModelForm):
+    class Meta:
+        model = TeamShiftsEmailQueue
+        fields = ("subject", "message", "send_after")
+        widgets = {
+            "send_after": forms.DateTimeInput(
+                attrs={"class": "form-control", "type": "datetime-local"},
+                format="%Y-%m-%dT%H:%M",
+            ),
+        }
+
+    def __init__(self, *args, event=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._event = event
+        if event is not None:
+            locales = list(event.settings.get("locales") or [event.settings.locale])
+            for field_name in ("subject", "message"):
+                self.fields[field_name].widget.enabled_locales = locales
+        self.fields["send_after"].input_formats = [
+            "%Y-%m-%dT%H:%M",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M",
+        ]
+
+
 __all__ = [
     "CallForTeamMembersSettingsForm",
     "CallForTeamMembersApplicationSettingsForm",
@@ -355,5 +433,7 @@ __all__ = [
     "TeamApplicationQuestionForm",
     "TeamMemberApplicationForm",
     "EmailTemplateForm",
+    "EmailComposeForm",
+    "EmailQueueEditForm",
     "render_answer_for_review",
 ]

--- a/teamshifts/services/email.py
+++ b/teamshifts/services/email.py
@@ -47,6 +47,7 @@ def queue_email(
     role_filter: TeamRole | None = None,
     status_filter: str = "",
     send_after=None,
+    dispatch: bool = True,
 ) -> TeamShiftsEmailQueue:
     with scope(event=event):
         queue = TeamShiftsEmailQueue.objects.create(
@@ -72,7 +73,7 @@ def queue_email(
         if rows:
             TeamShiftsEmailQueueRecipient.objects.bulk_create(rows)
 
-    if send_after is None:
+    if send_after is None and dispatch:
         _dispatch(event.pk, queue.pk)
     return queue
 

--- a/teamshifts/templates/teamshifts/base.html
+++ b/teamshifts/templates/teamshifts/base.html
@@ -56,4 +56,41 @@
             <span class="sidebar-text">{% trans "Applications" %}</span>
         </a>
     </li>
+    <li>
+        <a href="{% url 'plugins:teamshifts:email_outbox' organizer=request.organizer.slug event=request.event.slug %}"
+           class="has-children {% if url_name == 'email_compose' or url_name == 'email_outbox' or url_name == 'email_sent' or url_name == 'email_edit' or url_name == 'email_delete' or url_name == 'email_templates' or url_name == 'email_template_edit' %}active{% endif %}">
+            <span class="fa fa-fw fa-envelope"></span>
+            <span class="sidebar-text">{% trans "Emails" %}</span>
+        </a>
+        <a class="arrow" href="#" data-toggle="collapse" data-target="#collapse-emails">
+            <span class="fa arrow"></span>
+        </a>
+        <ul class="nav nav-second-level {% if url_name == 'email_compose' or url_name == 'email_outbox' or url_name == 'email_sent' or url_name == 'email_edit' or url_name == 'email_delete' or url_name == 'email_templates' or url_name == 'email_template_edit' %}in{% endif %}"
+            id="collapse-emails">
+            <li>
+                <a href="{% url 'plugins:teamshifts:email_compose' organizer=request.organizer.slug event=request.event.slug %}"
+                   {% if url_name == 'email_compose' %}class="active"{% endif %}>
+                    <span class="sidebar-text">{% trans "Compose" %}</span>
+                </a>
+            </li>
+            <li>
+                <a href="{% url 'plugins:teamshifts:email_outbox' organizer=request.organizer.slug event=request.event.slug %}"
+                   {% if url_name == 'email_outbox' or url_name == 'email_edit' or url_name == 'email_delete' %}class="active"{% endif %}>
+                    <span class="sidebar-text">{% trans "Outbox" %}</span>
+                </a>
+            </li>
+            <li>
+                <a href="{% url 'plugins:teamshifts:email_sent' organizer=request.organizer.slug event=request.event.slug %}"
+                   {% if url_name == 'email_sent' %}class="active"{% endif %}>
+                    <span class="sidebar-text">{% trans "Sent" %}</span>
+                </a>
+            </li>
+            <li>
+                <a href="{% url 'plugins:teamshifts:email_templates' organizer=request.organizer.slug event=request.event.slug %}"
+                   {% if url_name == 'email_templates' or url_name == 'email_template_edit' %}class="active"{% endif %}>
+                    <span class="sidebar-text">{% trans "Templates" %}</span>
+                </a>
+            </li>
+        </ul>
+    </li>
 {% endblock %}

--- a/teamshifts/templates/teamshifts/emails/compose.html
+++ b/teamshifts/templates/teamshifts/emails/compose.html
@@ -1,0 +1,76 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{% trans "Compose email" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+  <nav id='event-nav' class='header-nav'>
+    <div class='navigation'>
+      <div class='navigation-title'>
+        <h1>{% trans "Compose email" %}</h1>
+      </div>
+    </div>
+  </nav>
+
+  <p class='help-block'>
+    {% blocktrans trimmed %}
+      Write a message to your team members. You can filter recipients by role
+      and application status. Send immediately or schedule it for later.
+    {% endblocktrans %}
+  </p>
+
+  <form action='' method='post' class='form-horizontal'>
+    {% csrf_token %}
+    {% bootstrap_form_errors form %}
+
+    <fieldset>
+      <legend>{% trans "Recipients" %}</legend>
+      {% bootstrap_field form.role layout='control' %}
+      {% bootstrap_field form.status layout='control' %}
+    </fieldset>
+
+    <fieldset>
+      <legend>{% trans "Content" %}</legend>
+      {% bootstrap_field form.subject layout='control' %}
+      {% bootstrap_field form.message layout='control' %}
+    </fieldset>
+
+    <fieldset>
+      <legend>{% trans "Delivery" %}</legend>
+      {% bootstrap_field form.send_after layout='control' %}
+    </fieldset>
+
+    {% if preview_recipients is not None %}
+      <fieldset>
+        <legend>{% trans "Preview" %}</legend>
+        <div class='alert alert-info'>
+          {% blocktrans count count=preview_recipients|length trimmed %}
+            {{ count }} recipient matches the selected filters.
+          {% plural %}
+            {{ count }} recipients match the selected filters.
+          {% endblocktrans %}
+        </div>
+        {% if preview_recipients %}
+          <ul>
+            {% for user in preview_recipients|slice:':20' %}
+              <li>{{ user.email }}{% if user.fullname %} ({{ user.fullname }}){% endif %}</li>
+            {% endfor %}
+            {% if preview_recipients|length > 20 %}
+              <li>{% blocktrans with count=preview_recipients|length|add:'-20' %}and {{ count }} more{% endblocktrans %}</li>
+            {% endif %}
+          </ul>
+        {% endif %}
+      </fieldset>
+    {% endif %}
+
+    <div class='form-group submit-group'>
+      <button type='submit' class='btn btn-default btn-save' name='action' value='preview'>
+        {% trans "Preview recipients" %}
+      </button>
+      <button type='submit' class='btn btn-primary btn-save' name='action' value='send'>
+        {% trans "Send" %}
+      </button>
+    </div>
+  </form>
+{% endblock %}

--- a/teamshifts/templates/teamshifts/emails/compose.html
+++ b/teamshifts/templates/teamshifts/emails/compose.html
@@ -68,6 +68,9 @@
       <button type='submit' class='btn btn-default btn-save' name='action' value='preview'>
         {% trans "Preview recipients" %}
       </button>
+      <button type='submit' class='btn btn-default btn-save' name='action' value='draft'>
+        {% trans "Send to outbox" %}
+      </button>
       <button type='submit' class='btn btn-primary btn-save' name='action' value='send'>
         {% trans "Send" %}
       </button>

--- a/teamshifts/templates/teamshifts/emails/compose.html
+++ b/teamshifts/templates/teamshifts/emails/compose.html
@@ -65,7 +65,7 @@
     {% endif %}
 
     <div class='form-group submit-group'>
-      <button type='submit' class='btn btn-default btn-save' name='action' value='preview'>
+      <button type='submit' class='btn btn-default btn-save' name='action' value='preview' formnovalidate>
         {% trans "Preview recipients" %}
       </button>
       <button type='submit' class='btn btn-default btn-save' name='action' value='draft'>

--- a/teamshifts/templates/teamshifts/emails/delete_confirmation.html
+++ b/teamshifts/templates/teamshifts/emails/delete_confirmation.html
@@ -1,0 +1,34 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Delete email" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+  <nav id='event-nav' class='header-nav'>
+    <div class='navigation'>
+      <div class='navigation-title'>
+        <h1>{% trans "Delete email" %}</h1>
+      </div>
+    </div>
+  </nav>
+
+  <h4>{% trans "Do you really want to delete this email?" %}</h4>
+  <p><strong>{% trans "Subject" %}:</strong> {{ queue.subject }}</p>
+
+  <form method='post' class='submit-group'>
+    {% csrf_token %}
+    <div class='row'>
+      <div class='col-xs-6 text-left'>
+        <a href='{% url "plugins:teamshifts:email_outbox" organizer=request.organizer.slug event=request.event.slug %}'
+           class='btn btn-default btn-lg'>
+          {% trans "Back" %}
+        </a>
+      </div>
+      <div class='col-xs-6 text-right'>
+        <button type='submit' class='btn btn-danger btn-lg'>
+          <i class='fa fa-trash'></i> {% trans "Delete" %}
+        </button>
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/teamshifts/templates/teamshifts/emails/outbox_form.html
+++ b/teamshifts/templates/teamshifts/emails/outbox_form.html
@@ -1,0 +1,78 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{% trans "Edit email" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+  <nav id='event-nav' class='header-nav'>
+    <div class='navigation'>
+      <div class='navigation-title'>
+        <h1>{% trans "Edit email" %}</h1>
+      </div>
+    </div>
+  </nav>
+
+  {% if queue.sent_at %}
+    <div class='alert alert-info'>
+      {% blocktrans with timestamp=queue.sent_at %}
+        This email was sent on {{ timestamp }} and cannot be edited.
+      {% endblocktrans %}
+    </div>
+  {% endif %}
+
+  <form action='' method='post' class='form-horizontal'>
+    {% csrf_token %}
+    {% bootstrap_form_errors form %}
+    {% bootstrap_field form.subject layout='control' %}
+    {% bootstrap_field form.message layout='control' %}
+    {% bootstrap_field form.send_after layout='control' %}
+
+    <div class='form-group'>
+      <label class='col-md-3 control-label'>{% trans "Recipients" %}</label>
+      <div class='col-md-9'>
+        <ul class='list-unstyled'>
+          {% for recipient in queue.recipients.all|slice:':30' %}
+            <li>
+              {{ recipient.email }}
+              {% if recipient.sent_at %}
+                <span class='label label-success'>{% trans "sent" %}</span>
+              {% elif recipient.error %}
+                <span class='label label-danger'>{% trans "error" %}</span>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+
+    {% if not queue.sent_at %}
+      <div class='form-group submit-group'>
+        <div class='col-md-6 text-left'>
+          <a href='{% url "plugins:teamshifts:email_delete" organizer=request.organizer.slug event=request.event.slug pk=queue.pk %}'
+             class='btn btn-danger'>
+            <i class='fa fa-trash'></i> {% trans "Delete" %}
+          </a>
+        </div>
+        <div class='col-md-6 text-right'>
+          <a href='{% url "plugins:teamshifts:email_outbox" organizer=request.organizer.slug event=request.event.slug %}'
+             class='btn btn-default'>
+            {% trans "Cancel" %}
+          </a>
+          <button type='submit' class='btn btn-primary btn-save'>{% trans "Save" %}</button>
+        </div>
+      </div>
+    {% else %}
+      <div class='form-group submit-group'>
+        <a href='{% url "plugins:teamshifts:email_compose" organizer=request.organizer.slug event=request.event.slug %}?copy={{ queue.pk }}'
+           class='btn btn-primary'>
+          <i class='fa fa-copy'></i> {% trans "Copy to new email" %}
+        </a>
+        <a href='{% url "plugins:teamshifts:email_sent" organizer=request.organizer.slug event=request.event.slug %}'
+           class='btn btn-default'>
+          {% trans "Back" %}
+        </a>
+      </div>
+    {% endif %}
+  </form>
+{% endblock %}

--- a/teamshifts/templates/teamshifts/emails/outbox_list.html
+++ b/teamshifts/templates/teamshifts/emails/outbox_list.html
@@ -1,0 +1,96 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Outbox" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+  <nav id='event-nav' class='header-nav'>
+    <div class='navigation'>
+      <div class='navigation-title'>
+        <h1>
+          {% blocktrans count mail_count=mails|length trimmed %}
+            {{ mail_count }} pending email
+          {% plural %}
+            {{ mail_count }} pending emails
+          {% endblocktrans %}
+        </h1>
+      </div>
+    </div>
+  </nav>
+
+  <div class='submit-group'>
+    <a href='{% url "plugins:teamshifts:email_compose" organizer=request.organizer.slug event=request.event.slug %}'
+       class='btn btn-primary'>
+      <i class='fa fa-plus'></i> {% trans "New email" %}
+    </a>
+  </div>
+
+  <table class='table'>
+    <thead>
+      <tr>
+        <th>{% trans "Subject" %}</th>
+        <th>{% trans "Filters" %}</th>
+        <th>{% trans "Recipients" %}</th>
+        <th>{% trans "Scheduled for" %}</th>
+        <th>{% trans "Actions" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for mail in mails %}
+        <tr>
+          <td>
+            <a href='{% url "plugins:teamshifts:email_edit" organizer=request.organizer.slug event=request.event.slug pk=mail.pk %}'>
+              {{ mail.subject }}
+            </a>
+          </td>
+          <td>
+            {% if mail.role_filter %}
+              <span class='label label-default'>{{ mail.role_filter.name }}</span>
+            {% else %}
+              <span class='text-muted'>{% trans "All roles" %}</span>
+            {% endif %}
+            {% if mail.status_filter %}
+              <span class='label label-default'>{{ mail.get_status_filter_display }}</span>
+            {% endif %}
+          </td>
+          <td>{{ mail.recipient_count }}</td>
+          <td>
+            {% if mail.send_after %}
+              {{ mail.send_after|date:"SHORT_DATETIME_FORMAT" }}
+            {% else %}
+              <span class='text-muted'>{% trans "Immediately" %}</span>
+            {% endif %}
+          </td>
+          <td>
+            <div class='btn-toolbar' role='toolbar'>
+              <form method='post'
+                    action='{% url "plugins:teamshifts:email_send_now" organizer=request.organizer.slug event=request.event.slug pk=mail.pk %}'
+                    class='btn-group' role='group'>
+                {% csrf_token %}
+                <button type='submit' class='btn btn-sm btn-primary' title='{% trans "Send now" %}'>
+                  <i class='fa fa-paper-plane'></i>
+                </button>
+              </form>
+              <div class='btn-group' role='group'>
+                <a class='btn btn-sm btn-default' title='{% trans "Edit" %}'
+                   href='{% url "plugins:teamshifts:email_edit" organizer=request.organizer.slug event=request.event.slug pk=mail.pk %}'>
+                  <i class='fa fa-edit'></i>
+                </a>
+              </div>
+              <div class='btn-group' role='group'>
+                <a class='btn btn-sm btn-danger' title='{% trans "Delete" %}'
+                   href='{% url "plugins:teamshifts:email_delete" organizer=request.organizer.slug event=request.event.slug pk=mail.pk %}'>
+                  <i class='fa fa-trash'></i>
+                </a>
+              </div>
+            </div>
+          </td>
+        </tr>
+      {% empty %}
+        <tr>
+          <td colspan='5' class='text-muted'>{% trans "No pending emails." %}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/teamshifts/templates/teamshifts/emails/sent_list.html
+++ b/teamshifts/templates/teamshifts/emails/sent_list.html
@@ -1,0 +1,73 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Sent emails" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+  <nav id='event-nav' class='header-nav'>
+    <div class='navigation'>
+      <div class='navigation-title'>
+        <h1>
+          {% blocktrans count mail_count=mails|length trimmed %}
+            {{ mail_count }} sent email
+          {% plural %}
+            {{ mail_count }} sent emails
+          {% endblocktrans %}
+        </h1>
+      </div>
+    </div>
+  </nav>
+
+  <div class='submit-group'>
+    <a href='{% url "plugins:teamshifts:email_compose" organizer=request.organizer.slug event=request.event.slug %}'
+       class='btn btn-primary'>
+      <i class='fa fa-plus'></i> {% trans "New email" %}
+    </a>
+  </div>
+
+  <table class='table'>
+    <thead>
+      <tr>
+        <th>{% trans "Subject" %}</th>
+        <th>{% trans "Filters" %}</th>
+        <th>{% trans "Recipients" %}</th>
+        <th>{% trans "Sent at" %}</th>
+        <th>{% trans "Actions" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for mail in mails %}
+        <tr>
+          <td>
+            <a href='{% url "plugins:teamshifts:email_edit" organizer=request.organizer.slug event=request.event.slug pk=mail.pk %}'>
+              {{ mail.subject }}
+            </a>
+          </td>
+          <td>
+            {% if mail.role_filter %}
+              <span class='label label-default'>{{ mail.role_filter.name }}</span>
+            {% else %}
+              <span class='text-muted'>{% trans "All roles" %}</span>
+            {% endif %}
+            {% if mail.status_filter %}
+              <span class='label label-default'>{{ mail.get_status_filter_display }}</span>
+            {% endif %}
+          </td>
+          <td>{{ mail.recipient_count }}</td>
+          <td>{{ mail.sent_at|date:"SHORT_DATETIME_FORMAT" }}</td>
+          <td>
+            <a class='btn btn-sm btn-default'
+               href='{% url "plugins:teamshifts:email_compose" organizer=request.organizer.slug event=request.event.slug %}?copy={{ mail.pk }}'
+               title='{% trans "Copy" %}'>
+              <i class='fa fa-copy'></i> {% trans "Copy" %}
+            </a>
+          </td>
+        </tr>
+      {% empty %}
+        <tr>
+          <td colspan='5' class='text-muted'>{% trans "No sent emails yet." %}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -92,4 +92,34 @@ urlpatterns = [
         views.ApplicationStatusView.as_view(),
         name="application_status",
     ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/compose/",
+        views.EmailComposeView.as_view(),
+        name="email_compose",
+    ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/outbox/",
+        views.EmailOutboxView.as_view(),
+        name="email_outbox",
+    ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/sent/",
+        views.EmailSentView.as_view(),
+        name="email_sent",
+    ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/<int:pk>/edit/",
+        views.EmailQueueEditView.as_view(),
+        name="email_edit",
+    ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/<int:pk>/delete/",
+        views.EmailQueueDeleteView.as_view(),
+        name="email_delete",
+    ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/<int:pk>/send/",
+        views.EmailQueueSendNowView.as_view(),
+        name="email_send_now",
+    ),
 ]

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -701,7 +701,7 @@ class EmailOutboxView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateV
         event = self.request.event
         with scope(event=event):
             queues = list(
-                TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=True)
+                TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=True, user__isnull=False)
                 .select_related("role_filter", "user")
                 .prefetch_related("recipients")
                 .order_by("-created")
@@ -721,7 +721,7 @@ class EmailSentView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateVie
         event = self.request.event
         with scope(event=event):
             queues = list(
-                TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=False)
+                TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=False, user__isnull=False)
                 .select_related("role_filter", "user")
                 .prefetch_related("recipients")
                 .order_by("-sent_at")

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -661,9 +661,6 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
                     role = TeamRole.objects.filter(pk=role_id, event=event).first()
             recipients = get_recipients(event, role=role, status=status)
             self._preview_recipients = recipients
-            # Pass an UNBOUND form (no POST data) so validation never runs and
-            # no red "required" errors appear. Pre-fill with whatever the user
-            # already typed so they don't lose their work.
             form = EmailComposeForm(
                 event=event,
                 initial={
@@ -676,7 +673,6 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
             )
             return self.render_to_response(self.get_context_data(form=form))
         return super().post(request, *args, **kwargs)
-
 
     def form_valid(self, form):
         event = self.request.event

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -16,6 +16,8 @@ from eventyay.control.permissions import EventPermissionRequiredMixin
 from .forms import (
     CallForTeamMembersApplicationSettingsForm,
     CallForTeamMembersSettingsForm,
+    EmailComposeForm,
+    EmailQueueEditForm,
     EmailTemplateForm,
     TeamApplicationQuestionForm,
     TeamMemberApplicationForm,
@@ -33,10 +35,12 @@ from .models import (
     TeamApplicationQuestion,
     TeamMemberApplication,
     TeamRole,
+    TeamShiftsEmailQueue,
     TeamShiftsEmailTemplate,
     normalize_field_order,
 )
-from .services.email import queue_lifecycle_email
+from .services.email import get_recipients, queue_email, queue_lifecycle_email
+from .tasks import send_queued_email
 
 
 class PluginActiveMixin:
@@ -609,3 +613,212 @@ class PublicApplyThanksView(TemplateView):
         ctx = super().get_context_data(**kwargs)
         ctx["event"] = self.event
         return ctx
+
+
+class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/emails/compose.html"
+    form_class = EmailComposeForm
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["event"] = self.request.event
+        return kwargs
+
+    def get_initial(self):
+        initial = super().get_initial()
+        copy_pk = self.request.GET.get("copy")
+        if copy_pk and copy_pk.isdigit():
+            with scope(event=self.request.event):
+                try:
+                    source = TeamShiftsEmailQueue.objects.get(pk=int(copy_pk), event=self.request.event)
+                except TeamShiftsEmailQueue.DoesNotExist:
+                    return initial
+            initial["subject"] = source.subject
+            initial["message"] = source.message
+            initial["role"] = source.role_filter_id or None
+            initial["status"] = source.status_filter or ""
+        return initial
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["preview_recipients"] = getattr(self, "_preview_recipients", None)
+        return ctx
+
+    def form_invalid(self, form):
+        messages.error(self.request, _("Please correct the errors below."))
+        return super().form_invalid(form)
+
+    def form_valid(self, form):
+        event = self.request.event
+        role = form.cleaned_data.get("role")
+        status = form.cleaned_data.get("status") or ""
+        send_after = form.cleaned_data.get("send_after")
+
+        recipients = get_recipients(event, role=role, status=status)
+
+        if self.request.POST.get("action") == "preview":
+            self._preview_recipients = recipients
+            return self.render_to_response(self.get_context_data(form=form))
+
+        if not recipients:
+            messages.error(self.request, _("No recipients match the selected filters."))
+            return self.form_invalid(form)
+
+        queue_email(
+            event=event,
+            subject=form.cleaned_data["subject"],
+            message=form.cleaned_data["message"],
+            recipients=recipients,
+            user=self.request.user,
+            role_filter=role,
+            status_filter=status,
+            send_after=send_after,
+        )
+        if send_after:
+            messages.success(
+                self.request,
+                _("Email scheduled for %(count)d recipient(s). It stays in the outbox until %(when)s.") % {"count": len(recipients), "when": send_after},
+            )
+        else:
+            messages.success(
+                self.request,
+                _("Email queued for %(count)d recipient(s).") % {"count": len(recipients)},
+            )
+        return redirect(
+            "plugins:teamshifts:email_outbox" if send_after else "plugins:teamshifts:email_sent",
+            organizer=self.request.organizer.slug,
+            event=event.slug,
+        )
+
+
+class EmailOutboxView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateView):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/emails/outbox_list.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        with scope(event=event):
+            queues = list(
+                TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=True)
+                .select_related("role_filter", "user")
+                .prefetch_related("recipients")
+                .order_by("-created")
+            )
+            for q in queues:
+                q.recipient_count = q.recipients.count()
+        ctx["mails"] = queues
+        return ctx
+
+
+class EmailSentView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateView):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/emails/sent_list.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        with scope(event=event):
+            queues = list(
+                TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=False)
+                .select_related("role_filter", "user")
+                .prefetch_related("recipients")
+                .order_by("-sent_at")
+            )
+            for q in queues:
+                q.recipient_count = q.recipients.count()
+        ctx["mails"] = queues
+        return ctx
+
+
+class EmailQueueEditView(PluginActiveMixin, EventPermissionRequiredMixin, View):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/emails/outbox_form.html"
+
+    def _get_queue(self):
+        with scope(event=self.request.event):
+            queue = get_object_or_404(
+                TeamShiftsEmailQueue.objects.select_related("role_filter"),
+                pk=self.kwargs["pk"],
+                event=self.request.event,
+            )
+        return queue
+
+    def get(self, request, *args, **kwargs):
+        queue = self._get_queue()
+        form = EmailQueueEditForm(instance=queue, event=request.event)
+        return render(request, self.template_name, {"form": form, "queue": queue})
+
+    def post(self, request, *args, **kwargs):
+        queue = self._get_queue()
+        if queue.sent_at:
+            messages.error(request, _("This email has already been sent and cannot be edited."))
+            return redirect(
+                "plugins:teamshifts:email_outbox",
+                organizer=request.organizer.slug,
+                event=request.event.slug,
+            )
+        form = EmailQueueEditForm(request.POST, instance=queue, event=request.event)
+        if form.is_valid():
+            with scope(event=request.event):
+                form.save()
+            messages.success(request, _("Email saved."))
+            return redirect(
+                "plugins:teamshifts:email_outbox",
+                organizer=request.organizer.slug,
+                event=request.event.slug,
+            )
+        return render(request, self.template_name, {"form": form, "queue": queue})
+
+
+class EmailQueueDeleteView(PluginActiveMixin, EventPermissionRequiredMixin, View):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/emails/delete_confirmation.html"
+
+    def _get_queue(self):
+        with scope(event=self.request.event):
+            return get_object_or_404(
+                TeamShiftsEmailQueue,
+                pk=self.kwargs["pk"],
+                event=self.request.event,
+            )
+
+    def get(self, request, *args, **kwargs):
+        queue = self._get_queue()
+        return render(request, self.template_name, {"queue": queue})
+
+    def post(self, request, *args, **kwargs):
+        queue = self._get_queue()
+        if queue.sent_at:
+            messages.error(request, _("This email has already been sent and cannot be deleted."))
+        else:
+            with scope(event=request.event):
+                queue.delete()
+            messages.success(request, _("Email deleted."))
+        return redirect(
+            "plugins:teamshifts:email_outbox",
+            organizer=request.organizer.slug,
+            event=request.event.slug,
+        )
+
+
+class EmailQueueSendNowView(PluginActiveMixin, EventPermissionRequiredMixin, View):
+    permission = "can_change_event_settings"
+
+    def post(self, request, *args, **kwargs):
+        event = request.event
+        with scope(event=event):
+            queue = get_object_or_404(TeamShiftsEmailQueue, pk=kwargs["pk"], event=event)
+            if queue.sent_at:
+                messages.warning(request, _("This email has already been sent."))
+            else:
+                queue.send_after = None
+                queue.save(update_fields=["send_after"])
+                transaction.on_commit(lambda: send_queued_email.delay(event.pk, queue.pk))
+                messages.success(request, _("Email queued for sending."))
+        return redirect(
+            "plugins:teamshifts:email_outbox",
+            organizer=request.organizer.slug,
+            event=event.slug,
+        )

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -11,6 +11,7 @@ from django.utils.formats import date_format
 from django.utils.translation import gettext_lazy as _, ngettext
 from django.views.generic import FormView, TemplateView, View
 from django_scopes import scope, scopes_disabled
+from eventyay.base.i18n import LazyI18nString
 from eventyay.base.templatetags.rich_text import rich_text
 from eventyay.control.permissions import EventPermissionRequiredMixin
 
@@ -661,13 +662,16 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
                     role = TeamRole.objects.filter(pk=role_id, event=event).first()
             recipients = get_recipients(event, role=role, status=status)
             self._preview_recipients = recipients
+            locales = list(event.settings.get("locales") or [event.settings.locale])
+            subject_i18n = LazyI18nString({locales[i]: request.POST.get(f"subject_{i}", "") for i in range(len(locales))})
+            message_i18n = LazyI18nString({locales[i]: request.POST.get(f"message_{i}", "") for i in range(len(locales))})
             form = EmailComposeForm(
                 event=event,
                 initial={
                     "role": role,
                     "status": status,
-                    "subject": request.POST.get("subject", ""),
-                    "message": request.POST.get("message", ""),
+                    "subject": subject_i18n,
+                    "message": message_i18n,
                     "send_after": request.POST.get("send_after", ""),
                 },
             )

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -7,7 +7,8 @@ from django.db.models import Count, Q
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
+from django.utils.formats import date_format
+from django.utils.translation import gettext_lazy as _, ngettext
 from django.views.generic import FormView, TemplateView, View
 from django_scopes import scope
 from eventyay.base.templatetags.rich_text import rich_text
@@ -663,7 +664,7 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
 
         if not recipients:
             messages.error(self.request, _("No recipients match the selected filters."))
-            return self.form_invalid(form)
+            return self.render_to_response(self.get_context_data(form=form))
 
         queue_email(
             event=event,
@@ -678,15 +679,28 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
         if send_after:
             messages.success(
                 self.request,
-                _("Email scheduled for %(count)d recipient(s). It stays in the outbox until %(when)s.") % {"count": len(recipients), "when": send_after},
+                ngettext(
+                    "Email scheduled for %(count)d recipient. It stays in the outbox until %(when)s.",
+                    "Email scheduled for %(count)d recipients. It stays in the outbox until %(when)s.",
+                    len(recipients),
+                )
+                % {
+                    "count": len(recipients),
+                    "when": date_format(send_after, "SHORT_DATETIME_FORMAT"),
+                },
             )
         else:
             messages.success(
                 self.request,
-                _("Email queued for %(count)d recipient(s).") % {"count": len(recipients)},
+                ngettext(
+                    "Email queued for %(count)d recipient.",
+                    "Email queued for %(count)d recipients.",
+                    len(recipients),
+                )
+                % {"count": len(recipients)},
             )
         return redirect(
-            "plugins:teamshifts:email_outbox" if send_after else "plugins:teamshifts:email_sent",
+            "plugins:teamshifts:email_outbox",
             organizer=self.request.organizer.slug,
             event=event.slug,
         )
@@ -755,7 +769,7 @@ class EmailQueueEditView(PluginActiveMixin, EventPermissionRequiredMixin, View):
         if queue.sent_at:
             messages.error(request, _("This email has already been sent and cannot be edited."))
             return redirect(
-                "plugins:teamshifts:email_outbox",
+                "plugins:teamshifts:email_sent",
                 organizer=request.organizer.slug,
                 event=request.event.slug,
             )
@@ -797,7 +811,7 @@ class EmailQueueDeleteView(PluginActiveMixin, EventPermissionRequiredMixin, View
                 queue.delete()
             messages.success(request, _("Email deleted."))
         return redirect(
-            "plugins:teamshifts:email_outbox",
+            "plugins:teamshifts:email_sent" if queue.sent_at else "plugins:teamshifts:email_outbox",
             organizer=request.organizer.slug,
             event=request.event.slug,
         )
@@ -814,7 +828,7 @@ class EmailQueueSendNowView(PluginActiveMixin, EventPermissionRequiredMixin, Vie
                 messages.warning(request, _("This email has already been sent."))
             else:
                 queue.send_after = None
-                queue.save(update_fields=["send_after"])
+                queue.save(update_fields=["send_after", "updated"])
                 transaction.on_commit(lambda: send_queued_email.delay(event.pk, queue.pk))
                 messages.success(request, _("Email queued for sending."))
         return redirect(

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.utils.formats import date_format
 from django.utils.translation import gettext_lazy as _, ngettext
 from django.views.generic import FormView, TemplateView, View
-from django_scopes import scope
+from django_scopes import scope, scopes_disabled
 from eventyay.base.templatetags.rich_text import rich_text
 from eventyay.control.permissions import EventPermissionRequiredMixin
 
@@ -650,6 +650,34 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
         messages.error(self.request, _("Please correct the errors below."))
         return super().form_invalid(form)
 
+    def post(self, request, *args, **kwargs):
+        if request.POST.get("action") == "preview":
+            event = request.event
+            role_id = request.POST.get("role") or None
+            status = request.POST.get("status") or ""
+            role = None
+            if role_id:
+                with scopes_disabled():
+                    role = TeamRole.objects.filter(pk=role_id, event=event).first()
+            recipients = get_recipients(event, role=role, status=status)
+            self._preview_recipients = recipients
+            # Pass an UNBOUND form (no POST data) so validation never runs and
+            # no red "required" errors appear. Pre-fill with whatever the user
+            # already typed so they don't lose their work.
+            form = EmailComposeForm(
+                event=event,
+                initial={
+                    "role": role,
+                    "status": status,
+                    "subject": request.POST.get("subject", ""),
+                    "message": request.POST.get("message", ""),
+                    "send_after": request.POST.get("send_after", ""),
+                },
+            )
+            return self.render_to_response(self.get_context_data(form=form))
+        return super().post(request, *args, **kwargs)
+
+
     def form_valid(self, form):
         event = self.request.event
         role = form.cleaned_data.get("role")
@@ -729,11 +757,9 @@ class EmailOutboxView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateV
             queues = list(
                 TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=True, user__isnull=False)
                 .select_related("role_filter", "user")
-                .prefetch_related("recipients")
+                .annotate(recipient_count=Count("recipients"))
                 .order_by("-created")
             )
-            for q in queues:
-                q.recipient_count = q.recipients.count()
         ctx["mails"] = queues
         return ctx
 
@@ -749,11 +775,9 @@ class EmailSentView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateVie
             queues = list(
                 TeamShiftsEmailQueue.objects.filter(event=event, sent_at__isnull=False, user__isnull=False)
                 .select_related("role_filter", "user")
-                .prefetch_related("recipients")
+                .annotate(recipient_count=Count("recipients"))
                 .order_by("-sent_at")
             )
-            for q in queues:
-                q.recipient_count = q.recipients.count()
         ctx["mails"] = queues
         return ctx
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -658,7 +658,8 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
 
         recipients = get_recipients(event, role=role, status=status)
 
-        if self.request.POST.get("action") == "preview":
+        action = self.request.POST.get("action")
+        if action == "preview":
             self._preview_recipients = recipients
             return self.render_to_response(self.get_context_data(form=form))
 
@@ -675,6 +676,7 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
             role_filter=role,
             status_filter=status,
             send_after=send_after,
+            dispatch=(action != "draft"),
         )
         if send_after:
             messages.success(
@@ -688,6 +690,16 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
                     "count": len(recipients),
                     "when": date_format(send_after, "SHORT_DATETIME_FORMAT"),
                 },
+            )
+        elif action == "draft":
+            messages.success(
+                self.request,
+                ngettext(
+                    "Email saved to outbox for %(count)d recipient.",
+                    "Email saved to outbox for %(count)d recipients.",
+                    len(recipients),
+                )
+                % {"count": len(recipients)},
             )
         else:
             messages.success(


### PR DESCRIPTION
### Summary

Adds the organiser-facing email UI for TeamShifts — a dedicated Emails section in the sidebar with three pages: Compose, Outbox, and Sent. Organisers can write emails to volunteers filtered by role and application status, schedule them for later, preview the recipient list before sending, and manage pending messages from the Outbox.

### What changed

- **Compose** — subject, message (i18n), role filter, status filter, optional `send_after` scheduling. Preview action shows resolved recipient count before committing.
- **Outbox** — lists unsent queued emails with edit, delete, and send-now actions. Send-now clears `send_after` and dispatches the Celery task immediately.
- **Sent** — lists delivered emails with a Copy action that pre-fills the Compose form via `?copy=<pk>`.
- **`EmailComposeForm`** — i18n subject/message fields, role dropdown, status dropdown, datetime-local `send_after`.
- **`EmailQueueEditForm`** — edit unsent queue entries; read-only display for sent ones.
- **Sidebar nav** — new collapsible Emails group with Compose, Outbox, Sent, Templates children.
- **5 templates** — `emails/compose.html`, `outbox_list.html`, `sent_list.html`, `outbox_form.html`, `delete_confirmation.html`.

### How it works

All recipient resolution goes through `services/email.get_recipients()` (from the email infrastructure PR). Queueing goes through `queue_email()`. Send-now dispatches `send_queued_email.delay()` via Celery. All views use `PluginActiveMixin` + `EventPermissionRequiredMixin` and wrap ORM queries in `scope(event=event)`.

### Testing

> Transactional emails on form submissions are auto-triggered (no manual compose needed)

1. Go to TeamShifts → Emails → Compose
2. Fill subject/message, pick role + status, click Preview → see recipient count
3. Send immediately → appears in Sent list
4. Send with a future `send_after` → appears in Outbox; use Send Now button to dispatch early 
(Email scheduling - part of #62) 
5. Copy a sent email → lands back on Compose pre-filled
6. Edit/delete an outbox entry



https://github.com/user-attachments/assets/7cb01fdf-d8b5-4a40-aaab-1c542a7de629




### Risk

No new migrations. No schema changes. All new code is additive views and templates on top of the queue models from #30

#### Related

Closes #28 
Part of #25 #6 