### PR TITLE
feat: restructure application review workflow

### DIFF
--- a/teamshifts/templates/teamshifts/application_detail.html
+++ b/teamshifts/templates/teamshifts/application_detail.html
@@ -1,0 +1,100 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Application Details" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+    <nav id="event-nav" class="header-nav">
+        <div class="navigation">
+            <div class="navigation-title">
+                <h1>{% trans "Application Details" %}</h1>
+            </div>
+        </div>
+    </nav>
+    
+    <div style="margin-bottom: 20px;">
+        <a href="{% url 'plugins:teamshifts:applications' organizer=request.organizer.slug event=request.event.slug %}" class="btn btn-default">
+            <span class="fa fa-arrow-left"></span> {% trans "Back to applications list" %}
+        </a>
+        
+        {% if application.status == 'pending' %}
+        <form action="{% url 'plugins:teamshifts:application_status' organizer=request.organizer.slug event=request.event.slug pk=application.pk %}"
+              method="post" class="helper-display-inline" style="float: right;">
+            {% csrf_token %}
+            <button type="submit" name="action" value="accept" class="btn btn-success">
+                <span class="fa fa-check"></span> {% trans "Accept" %}
+            </button>
+            <button type="submit" name="action" value="reject" class="btn btn-danger">
+                <span class="fa fa-times"></span> {% trans "Reject" %}
+            </button>
+        </form>
+        {% endif %}
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Applicant Information" %}</h3>
+        </div>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th>{% trans "Email" %}</th>
+                    <td>{{ application.user.email }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Name" %}</th>
+                    <td>{{ application.user.fullname|default:"—" }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Phone" %}</th>
+                    <td>{{ application.phone|default:"—" }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans "Role" %}</th>
+                    <td><span class="label label-info">{{ application.role.name }}</span></td>
+                </tr>
+                <tr>
+                    <th>{% trans "Status" %}</th>
+                    <td>
+                        {% if application.status == 'pending' %}
+                            <span class="label label-warning">{% trans "Pending" %}</span>
+                        {% elif application.status == 'accepted' %}
+                            <span class="label label-success">{% trans "Accepted" %}</span>
+                        {% else %}
+                            <span class="label label-danger">{% trans "Rejected" %}</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>{% trans "Applied on" %}</th>
+                    <td>{{ application.created_at|date:"SHORT_DATETIME_FORMAT" }}</td>
+                </tr>
+                {% if application.availability_notes %}
+                <tr>
+                    <th>{% trans "Availability notes" %}</th>
+                    <td>{{ application.availability_notes|linebreaksbr }}</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+
+    {% if application.rendered_answers %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Form Answers" %}</h3>
+        </div>
+        <table class="table">
+            <tbody>
+                {% for entry in application.rendered_answers %}
+                <tr>
+                    <th style="width: 40%">{{ entry.question.question }}</th>
+                    <td>{{ entry.value|default:"—" }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+{% endblock %}

--- a/teamshifts/templates/teamshifts/applications.html
+++ b/teamshifts/templates/teamshifts/applications.html
@@ -65,18 +65,18 @@
                             </td>
                             <td>{{ app.created_at|date:"SHORT_DATETIME_FORMAT" }}</td>
                             <td class="text-right flip">
-                                <a href="{% url 'plugins:teamshifts:application_detail' organizer=request.organizer.slug event=request.event.slug pk=app.pk %}" class="btn btn-default btn-sm" title="{% trans 'View details' %}">
-                                    <span class="fa fa-eye"></span>
+                                <a href="{% url 'plugins:teamshifts:application_detail' organizer=request.organizer.slug event=request.event.slug pk=app.pk %}" class="btn btn-default btn-sm" title="{% trans 'View details' %}" aria-label="{% trans 'View details' %}">
+                                    <span class="fa fa-eye" aria-hidden="true"></span>
                                 </a>
                                 {% if app.status == 'pending' %}
                                     <form action="{% url 'plugins:teamshifts:application_status' organizer=request.organizer.slug event=request.event.slug pk=app.pk %}"
                                           method="post" class="helper-display-inline">
                                         {% csrf_token %}
-                                        <button type="submit" name="action" value="accept" class="btn btn-success btn-sm" title="{% trans 'Accept' %}">
-                                            <span class="fa fa-check"></span>
+                                        <button type="submit" name="action" value="accept" class="btn btn-success btn-sm" title="{% trans 'Accept' %}" aria-label="{% trans 'Accept' %}">
+                                            <span class="fa fa-check" aria-hidden="true"></span>
                                         </button>
-                                        <button type="submit" name="action" value="reject" class="btn btn-danger btn-sm" title="{% trans 'Reject' %}">
-                                            <span class="fa fa-times"></span>
+                                        <button type="submit" name="action" value="reject" class="btn btn-danger btn-sm" title="{% trans 'Reject' %}" aria-label="{% trans 'Reject' %}">
+                                            <span class="fa fa-times" aria-hidden="true"></span>
                                         </button>
                                     </form>
                                 {% endif %}

--- a/teamshifts/templates/teamshifts/applications.html
+++ b/teamshifts/templates/teamshifts/applications.html
@@ -40,12 +40,10 @@
             <table class="table table-hover table-quotas">
                 <thead>
                     <tr>
-                        <th>{% trans "Applicant" %}</th>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Phone" %}</th>
-                        <th>{% trans "Role" %}</th>
+                        {% for col in columns %}
+                            <th>{{ col.label }}</th>
+                        {% endfor %}
                         <th>{% trans "Status" %}</th>
-                        <th>{% trans "Attendance" %}</th>
                         <th>{% trans "Applied" %}</th>
                         <th class="action-col-2"></th>
                     </tr>
@@ -53,10 +51,9 @@
                 <tbody>
                     {% for app in applications %}
                         <tr>
-                            <td>{{ app.user.email }}</td>
-                            <td>{{ app.user.fullname|default:"—" }}</td>
-                            <td>{{ app.phone|default:"—" }}</td>
-                            <td><span class="label label-info">{{ app.role.name }}</span></td>
+                            {% for val in app.dynamic_values %}
+                                <td>{{ val|default:"—" }}</td>
+                            {% endfor %}
                             <td>
                                 {% if app.status == 'pending' %}
                                     <span class="label label-warning">{% trans "Pending" %}</span>
@@ -66,58 +63,25 @@
                                     <span class="label label-danger">{% trans "Rejected" %}</span>
                                 {% endif %}
                             </td>
-                            <td>
-                                {% if app.attendance_confirmed is None %}
-                                    <span class="label label-default">—</span>
-                                {% elif app.attendance_confirmed %}
-                                    <span class="label label-success">{% trans "Confirmed" %}</span>
-                                {% else %}
-                                    <span class="label label-danger">{% trans "Declined" %}</span>
-                                {% endif %}
-                            </td>
                             <td>{{ app.created_at|date:"SHORT_DATETIME_FORMAT" }}</td>
                             <td class="text-right flip">
-                                {% if app.availability_notes or app.rendered_answers %}
-                                    <button type="button" class="btn btn-default btn-sm" data-toggle="collapse"
-                                            data-target="#app-details-{{ app.pk }}"
-                                            aria-expanded="false">
-                                        <span class="fa fa-info-circle"></span> {% trans "Details" %}
-                                    </button>
-                                {% endif %}
+                                <a href="{% url 'plugins:teamshifts:application_detail' organizer=request.organizer.slug event=request.event.slug pk=app.pk %}" class="btn btn-default btn-sm" title="{% trans 'View details' %}">
+                                    <span class="fa fa-eye"></span>
+                                </a>
                                 {% if app.status == 'pending' %}
                                     <form action="{% url 'plugins:teamshifts:application_status' organizer=request.organizer.slug event=request.event.slug pk=app.pk %}"
                                           method="post" class="helper-display-inline">
                                         {% csrf_token %}
-                                        <button type="submit" name="action" value="accept" class="btn btn-success btn-sm">
+                                        <button type="submit" name="action" value="accept" class="btn btn-success btn-sm" title="{% trans 'Accept' %}">
                                             <span class="fa fa-check"></span>
                                         </button>
-                                        <button type="submit" name="action" value="reject" class="btn btn-danger btn-sm">
+                                        <button type="submit" name="action" value="reject" class="btn btn-danger btn-sm" title="{% trans 'Reject' %}">
                                             <span class="fa fa-times"></span>
                                         </button>
                                     </form>
                                 {% endif %}
                             </td>
                         </tr>
-                        {% if app.availability_notes or app.rendered_answers %}
-                            <tr id="app-details-{{ app.pk }}" class="collapse">
-                                <td colspan="8" class="teamshifts-application-details">
-                                    {% if app.availability_notes %}
-                                        <p>
-                                            <strong>{% trans "Availability notes" %}:</strong>
-                                            <span class="teamshifts-answer-text">{{ app.availability_notes }}</span>
-                                        </p>
-                                    {% endif %}
-                                    {% if app.rendered_answers %}
-                                        <dl class="teamshifts-answer-list">
-                                            {% for entry in app.rendered_answers %}
-                                                <dt>{{ entry.question.question }}</dt>
-                                                <dd class="teamshifts-answer-text">{{ entry.value|default:"—" }}</dd>
-                                            {% endfor %}
-                                        </dl>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -122,4 +122,9 @@ urlpatterns = [
         views.EmailQueueSendNowView.as_view(),
         name="email_send_now",
     ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/applications/<int:pk>/",
+        views.ApplicationDetailView.as_view(),
+        name="application_detail",
+    ),
 ]

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -82,4 +82,9 @@ urlpatterns = [
         views.ApplicationStatusView.as_view(),
         name="application_status",
     ),
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/applications/<int:pk>/",
+        views.ApplicationDetailView.as_view(),
+        name="application_detail",
+    ),
 ]

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -397,11 +397,52 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
             if search:
                 qs = qs.filter(Q(user__email__icontains=search) | Q(user__fullname__icontains=search))
 
+            try:
+                cfm = event.call_for_team_members
+                field_order = normalize_field_order(list(cfm.field_order))
+            except CallForTeamMembers.DoesNotExist:
+                field_order = list(CFM_BUILTIN_FIELD_KEYS)
+
+            dynamic_keys = [k for k in field_order if k != "role"][:4]
+
+            columns = []
+            custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event)}
+
+            for key in dynamic_keys:
+                if key == "full_name":
+                    columns.append({"key": key, "label": _("Name")})
+                elif key == "email":
+                    columns.append({"key": key, "label": _("Email")})
+                elif key == "phone":
+                    columns.append({"key": key, "label": _("Phone")})
+                elif key == "availability":
+                    columns.append({"key": key, "label": _("Availability")})
+                elif key in custom_questions:
+                    columns.append({"key": key, "label": custom_questions[key]})
+
             applications = list(qs)
             for app in applications:
+                app_dynamic_values = []
+                answers_dict = {str(a.question_id): render_answer_for_review(a.question, a.answer) for a in app.answers.all()}
+                
+                for col in columns:
+                    key = col["key"]
+                    if key == "full_name":
+                        app_dynamic_values.append(app.user.fullname)
+                    elif key == "email":
+                        app_dynamic_values.append(app.user.email)
+                    elif key == "phone":
+                        app_dynamic_values.append(app.phone)
+                    elif key == "availability":
+                        app_dynamic_values.append(app.availability_notes)
+                    else:
+                        app_dynamic_values.append(answers_dict.get(key, ""))
+                
+                app.dynamic_values = app_dynamic_values
                 app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
 
             ctx["applications"] = applications
+            ctx["columns"] = columns
             ctx["roles"] = list(TeamRole.objects.filter(event=event))
             ctx["status_choices"] = ApplicationStatus.choices
             ctx["current_status"] = status_filter
@@ -432,7 +473,25 @@ class ApplicationStatusView(PluginActiveMixin, EventPermissionRequiredMixin, Vie
                 messages.warning(request, _("Application by %s rejected.") % application.user.email)
             else:
                 raise Http404
-        return redirect("plugins:teamshifts:applications", organizer=request.organizer.slug, event=event.slug)
+        return redirect(reverse("plugins:teamshifts:applications", kwargs={"organizer": event.organizer.slug, "event": event.slug}))
+
+
+class ApplicationDetailView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateView):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/application_detail.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        with scope(event=event):
+            app = get_object_or_404(
+                TeamMemberApplication.objects.select_related("user", "role").prefetch_related("answers__question"),
+                pk=kwargs["pk"],
+                event=event,
+            )
+            app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
+            ctx["application"] = app
+        return ctx
 
 
 class PublicApplyView(FormView):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -408,7 +408,8 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
             columns = []
             custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event)}
 
-            for key in dynamic_keys:
+            for raw_key in dynamic_keys:
+                key = str(raw_key)
                 if key == "full_name":
                     columns.append({"key": key, "label": _("Name")})
                 elif key == "email":

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -424,7 +424,7 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
             for app in applications:
                 app_dynamic_values = []
                 answers_dict = {str(a.question_id): render_answer_for_review(a.question, a.answer) for a in app.answers.all()}
-                
+
                 for col in columns:
                     key = col["key"]
                     if key == "full_name":
@@ -437,7 +437,7 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
                         app_dynamic_values.append(app.availability_notes)
                     else:
                         app_dynamic_values.append(answers_dict.get(key, ""))
-                
+
                 app.dynamic_values = app_dynamic_values
                 app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -494,7 +494,8 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
             columns = []
             custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event)}
 
-            for key in dynamic_keys:
+            for raw_key in dynamic_keys:
+                key = str(raw_key)
                 if key == "full_name":
                     columns.append({"key": key, "label": _("Name")})
                 elif key == "email":

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -401,12 +401,24 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
                 cfm = event.call_for_team_members
                 field_order = normalize_field_order(list(cfm.field_order))
             except CallForTeamMembers.DoesNotExist:
+                cfm = None
                 field_order = list(CFM_BUILTIN_FIELD_KEYS)
 
-            dynamic_keys = [k for k in field_order if k != "role"][:4]
+            custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event, active=True)}
 
+            active_keys = []
+            for k in field_order:
+                if k == "role":
+                    continue
+                if k in CFM_BUILTIN_FIELD_KEYS:
+                    if cfm and getattr(cfm, f"ask_{k}", "optional") == "do_not_ask":
+                        continue
+                    active_keys.append(k)
+                elif str(k) in custom_questions:
+                    active_keys.append(k)
+
+            dynamic_keys = active_keys[:4]
             columns = []
-            custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event)}
 
             for raw_key in dynamic_keys:
                 key = str(raw_key)
@@ -440,7 +452,6 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
                         app_dynamic_values.append(answers_dict.get(key, ""))
 
                 app.dynamic_values = app_dynamic_values
-                app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
 
             ctx["applications"] = applications
             ctx["columns"] = columns

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -483,11 +483,52 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
             if search:
                 qs = qs.filter(Q(user__email__icontains=search) | Q(user__fullname__icontains=search))
 
+            try:
+                cfm = event.call_for_team_members
+                field_order = normalize_field_order(list(cfm.field_order))
+            except CallForTeamMembers.DoesNotExist:
+                field_order = list(CFM_BUILTIN_FIELD_KEYS)
+
+            dynamic_keys = [k for k in field_order if k != "role"][:4]
+
+            columns = []
+            custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event)}
+
+            for key in dynamic_keys:
+                if key == "full_name":
+                    columns.append({"key": key, "label": _("Name")})
+                elif key == "email":
+                    columns.append({"key": key, "label": _("Email")})
+                elif key == "phone":
+                    columns.append({"key": key, "label": _("Phone")})
+                elif key == "availability":
+                    columns.append({"key": key, "label": _("Availability")})
+                elif key in custom_questions:
+                    columns.append({"key": key, "label": custom_questions[key]})
+
             applications = list(qs)
             for app in applications:
+                app_dynamic_values = []
+                answers_dict = {str(a.question_id): render_answer_for_review(a.question, a.answer) for a in app.answers.all()}
+                
+                for col in columns:
+                    key = col["key"]
+                    if key == "full_name":
+                        app_dynamic_values.append(app.user.fullname)
+                    elif key == "email":
+                        app_dynamic_values.append(app.user.email)
+                    elif key == "phone":
+                        app_dynamic_values.append(app.phone)
+                    elif key == "availability":
+                        app_dynamic_values.append(app.availability_notes)
+                    else:
+                        app_dynamic_values.append(answers_dict.get(key, ""))
+                
+                app.dynamic_values = app_dynamic_values
                 app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
 
             ctx["applications"] = applications
+            ctx["columns"] = columns
             ctx["roles"] = list(TeamRole.objects.filter(event=event))
             ctx["status_choices"] = ApplicationStatus.choices
             ctx["current_status"] = status_filter
@@ -520,7 +561,25 @@ class ApplicationStatusView(PluginActiveMixin, EventPermissionRequiredMixin, Vie
                 transaction.on_commit(lambda app=application: queue_lifecycle_email(app, EmailTemplateRoles.APPLICATION_REJECTED))
             else:
                 raise Http404
-        return redirect("plugins:teamshifts:applications", organizer=request.organizer.slug, event=event.slug)
+        return redirect(reverse("plugins:teamshifts:applications", kwargs={"organizer": event.organizer.slug, "event": event.slug}))
+
+
+class ApplicationDetailView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateView):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/application_detail.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        with scope(event=event):
+            app = get_object_or_404(
+                TeamMemberApplication.objects.select_related("user", "role").prefetch_related("answers__question"),
+                pk=kwargs["pk"],
+                event=event,
+            )
+            app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
+            ctx["application"] = app
+        return ctx
 
 
 class PublicApplyView(FormView):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -510,7 +510,7 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
             for app in applications:
                 app_dynamic_values = []
                 answers_dict = {str(a.question_id): render_answer_for_review(a.question, a.answer) for a in app.answers.all()}
-                
+
                 for col in columns:
                     key = col["key"]
                     if key == "full_name":
@@ -523,7 +523,7 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
                         app_dynamic_values.append(app.availability_notes)
                     else:
                         app_dynamic_values.append(answers_dict.get(key, ""))
-                
+
                 app.dynamic_values = app_dynamic_values
                 app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -487,12 +487,24 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
                 cfm = event.call_for_team_members
                 field_order = normalize_field_order(list(cfm.field_order))
             except CallForTeamMembers.DoesNotExist:
+                cfm = None
                 field_order = list(CFM_BUILTIN_FIELD_KEYS)
 
-            dynamic_keys = [k for k in field_order if k != "role"][:4]
+            custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event, active=True)}
 
+            active_keys = []
+            for k in field_order:
+                if k == "role":
+                    continue
+                if k in CFM_BUILTIN_FIELD_KEYS:
+                    if cfm and getattr(cfm, f"ask_{k}", "optional") == "do_not_ask":
+                        continue
+                    active_keys.append(k)
+                elif str(k) in custom_questions:
+                    active_keys.append(k)
+
+            dynamic_keys = active_keys[:4]
             columns = []
-            custom_questions = {str(q.pk): q.question for q in TeamApplicationQuestion.objects.filter(event=event)}
 
             for raw_key in dynamic_keys:
                 key = str(raw_key)
@@ -526,7 +538,6 @@ class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, Templ
                         app_dynamic_values.append(answers_dict.get(key, ""))
 
                 app.dynamic_values = app_dynamic_values
-                app.rendered_answers = [{"question": a.question, "value": render_answer_for_review(a.question, a.answer)} for a in app.answers.all()]
 
             ctx["applications"] = applications
             ctx["columns"] = columns


### PR DESCRIPTION
### Description
This PR improves the Application Review experience for organizers by implementing Issues 

It splits the application information into a dynamic "Quick Scan Table" for faster triage, and a comprehensive "Application Detail Page" for in-depth review.

### Changes
* **Quick Scan Table (Issue 41):**
  * Removed static columns (`Applicant`, `Name`, `Phone`, `Role`, `Attendance`).
  * The table now dynamically renders the first 4 fields defined in the organizer's `CallForTeamMembers` settings.
  * Explicitly excluded `Role` and `Attendance` from the table view to reduce clutter.
  * Removed the old collapsible row (accordion) that displayed the application details inline.
* **Application Detail Page (Issue 43):**
  * Created a new dedicated page (`application_detail.html`) at `/applications/<int:pk>/`.
  * The detail page displays all standard fields (Email, Name, Phone, Role, Availability) and any custom answers.
  * Added quick "Accept" and "Reject" action buttons directly on the detail page (only visible for `pending` applications).
  * Added a "Back to applications list" button for easy navigation.
* **Navigation:**
  * Added a "View" button (eye icon) in the applications table to navigate to the individual detail page.


https://github.com/user-attachments/assets/f0fdc53e-1d01-4b96-bede-acb121569323



#### Related
* Closes #41
* Closes #43