### PR TITLE
feat: add edit functionality for team roles

### DIFF
--- a/teamshifts/templates/teamshifts/role_edit.html
+++ b/teamshifts/templates/teamshifts/role_edit.html
@@ -1,0 +1,39 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{% trans "Edit Role" %} :: {{ request.event.name }}{% endblock %}
+
+{% block content %}
+    <nav id='event-nav' class='header-nav'>
+        <div class='navigation'>
+            <div class='navigation-title'>
+                <h1>{% blocktrans trimmed with name=role.name %}Edit Role "{{ name }}"{% endblocktrans %}</h1>
+            </div>
+            <div class='navigation-action'>
+                <a href='{% url "plugins:teamshifts:roles" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-default'>
+                    {% trans "Back" %}
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <div class='panel panel-default'>
+        <div class='panel-heading'>
+            <h3 class='panel-title'>{% trans "Role details" %}</h3>
+        </div>
+        <div class='panel-body'>
+            <form action='' method='post' class='form-horizontal'>
+                {% csrf_token %}
+                {% bootstrap_form_errors form %}
+                {% bootstrap_field form.name layout="control" %}
+                {% bootstrap_field form.description layout="control" %}
+                <div class='form-group submit-group'>
+                    <button type='submit' class='btn btn-primary btn-save'>
+                        <span class='fa fa-save'></span> {% trans "Save" %}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/teamshifts/templates/teamshifts/roles.html
+++ b/teamshifts/templates/teamshifts/roles.html
@@ -25,7 +25,7 @@
                         <th>{% trans "Role name" %}</th>
                         <th>{% trans "Description" %}</th>
                         <th>{% trans "Applications" %}</th>
-                        <th class='action-col-1'></th>
+                        <th class='action-col-2'></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -35,6 +35,10 @@
                             <td class='text-muted'>{{ role.description|default:"—" }}</td>
                             <td>{{ role.application_count }}</td>
                             <td class='text-right flip'>
+                                <a href='{% url "plugins:teamshifts:role_edit" organizer=request.organizer.slug event=request.event.slug pk=role.pk %}'
+                                   class='btn btn-default btn-sm'>
+                                    <span class='fa fa-edit'></span>
+                                </a>
                                 <form action='{% url "plugins:teamshifts:role_delete" organizer=request.organizer.slug event=request.event.slug pk=role.pk %}'
                                       method='post'
                                       class='helper-display-inline'>

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -48,6 +48,11 @@ urlpatterns = [
         name="role_delete",
     ),
     path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/roles/<int:pk>/edit/",
+        views.TeamRoleEditView.as_view(),
+        name="role_edit",
+    ),
+    path(
         "teamshifts/event/<orgslug:organizer>/<slug:event>/locations/",
         views.ShiftLocationListView.as_view(),
         name="locations",

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -273,6 +273,30 @@ class TeamRoleDeleteView(PluginActiveMixin, EventPermissionRequiredMixin, View):
         return redirect("plugins:teamshifts:roles", organizer=request.organizer.slug, event=event.slug)
 
 
+class TeamRoleEditView(PluginActiveMixin, EventPermissionRequiredMixin, View):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/role_edit.html"
+
+    def get(self, request, *args, **kwargs):
+        with scope(event=request.event):
+            role = get_object_or_404(TeamRole, pk=kwargs["pk"], event=request.event)
+        form = TeamRoleForm(instance=role)
+        return render(request, self.template_name, {"form": form, "role": role})
+
+    def post(self, request, *args, **kwargs):
+        with scope(event=request.event):
+            role = get_object_or_404(TeamRole, pk=kwargs["pk"], event=request.event)
+        form = TeamRoleForm(request.POST, instance=role)
+        with scope(event=request.event):
+            is_valid = form.is_valid()
+            if is_valid:
+                form.save()
+        if is_valid:
+            messages.success(request, _("Role '%s' updated.") % role.name)
+            return redirect("plugins:teamshifts:roles", organizer=request.organizer.slug, event=request.event.slug)
+        return render(request, self.template_name, {"form": form, "role": role})
+
+
 class EmailTemplateListView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
     template_name = "teamshifts/email_templates.html"

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -280,20 +280,20 @@ class TeamRoleEditView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         with scope(event=request.event):
             role = get_object_or_404(TeamRole, pk=kwargs["pk"], event=request.event)
-        form = TeamRoleForm(instance=role)
+            form = TeamRoleForm(instance=role)
         return render(request, self.template_name, {"form": form, "role": role})
 
     def post(self, request, *args, **kwargs):
         with scope(event=request.event):
             role = get_object_or_404(TeamRole, pk=kwargs["pk"], event=request.event)
-        form = TeamRoleForm(request.POST, instance=role)
-        with scope(event=request.event):
-            is_valid = form.is_valid()
-            if is_valid:
+            form = TeamRoleForm(request.POST, instance=role)
+            if form.is_valid():
                 form.save()
-        if is_valid:
-            messages.success(request, _("Role '%s' updated.") % role.name)
-            return redirect("plugins:teamshifts:roles", organizer=request.organizer.slug, event=request.event.slug)
+                messages.success(request, _("Role '%s' updated.") % role.name)
+                return redirect("plugins:teamshifts:roles", organizer=request.organizer.slug, event=request.event.slug)
+
+            # Refresh the role from DB to discard any invalid form data applied to the instance
+            role.refresh_from_db()
         return render(request, self.template_name, {"form": form, "role": role})
 
 


### PR DESCRIPTION
**Changes**

1. **[views.py]** — `TeamRoleEditView`: handles `GET` (render form pre-filled with existing data) and `POST` (validate, save, redirect). Uses the same scope/pattern as `ShiftLocationUpdateView`. The existing `TeamRoleForm` already handles the duplicate-name validation correctly for edits (it excludes the current instance's own name).

2. **[urls.py]** — Added `roles/<int:pk>/edit/` → `role_edit`

3. **[role_edit.html]** — Edit form page with a "Back" button to the roles list

4. **[roles.html]** — Added a pencil `fa-edit` button per row (before the trash button), widened action column from `action-col-1` to `action-col-2`



https://github.com/user-attachments/assets/935ac202-fd9c-4d28-a1b4-d640d8be9701



Closes #69 