### PR TITLE
fix: move members page arrived-toggle script to external file to avoid CSP block

### DIFF
--- a/teamshifts/static/teamshifts/members.js
+++ b/teamshifts/static/teamshifts/members.js
@@ -3,7 +3,7 @@ function gettext(msgid) {
 }
 
 /**
- * @throws {Error} when the network request fails
+ * @throws {Error} when the request fails (network error or non-2xx response)
  */
 async function toggleArrived(form) {
     const response = await fetch(form.action, {
@@ -13,17 +13,19 @@ async function toggleArrived(form) {
             "X-Requested-With": "XMLHttpRequest",
         },
     });
+    if (!response.ok) {
+        throw new Error(`Toggle arrived request failed with status ${response.status}`);
+    }
     return response.json();
 }
 
 function setButtonState(button, arrived) {
-    if (arrived) {
-        button.className = "btn btn-sm btn-success";
-        button.innerHTML = `<i class="fa fa-check"></i> ${gettext("Arrived")}`;
-    } else {
-        button.className = "btn btn-sm btn-default";
-        button.innerHTML = `<i class="fa fa-times"></i> ${gettext("Not arrived")}`;
-    }
+    button.className = arrived ? "btn btn-sm btn-success" : "btn btn-sm btn-default";
+    const icon = document.createElement("i");
+    icon.className = arrived ? "fa fa-check" : "fa fa-times";
+    button.innerHTML = "";
+    button.appendChild(icon);
+    button.appendChild(document.createTextNode(` ${gettext(arrived ? "Arrived" : "Not arrived")}`));
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -46,6 +48,7 @@ document.addEventListener("DOMContentLoaded", () => {
             } catch (error) {
                 console.error("Failed to toggle arrived status", error);
                 button.innerHTML = originalHtml;
+                alert(gettext("An error occurred."));
             } finally {
                 button.disabled = false;
             }

--- a/teamshifts/static/teamshifts/members.js
+++ b/teamshifts/static/teamshifts/members.js
@@ -23,9 +23,19 @@ function setButtonState(button, arrived) {
     button.className = arrived ? "btn btn-sm btn-success" : "btn btn-sm btn-default";
     const icon = document.createElement("i");
     icon.className = arrived ? "fa fa-check" : "fa fa-times";
-    button.innerHTML = "";
+    const label = document.createTextNode(` ${gettext(arrived ? "Arrived" : "Not arrived")}`);
+    button.replaceChildren(icon, label);
+}
+
+function setButtonLoading(button) {
+    button.replaceChildren();
+    const icon = document.createElement("i");
+    icon.className = "fa fa-spinner fa-spin";
     button.appendChild(icon);
-    button.appendChild(document.createTextNode(` ${gettext(arrived ? "Arrived" : "Not arrived")}`));
+}
+
+function restoreButtonChildren(button, originalChildren) {
+    button.replaceChildren(...originalChildren);
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -33,21 +43,21 @@ document.addEventListener("DOMContentLoaded", () => {
         form.addEventListener("submit", async (event) => {
             event.preventDefault();
             const button = form.querySelector("button");
-            const originalHtml = button.innerHTML;
+            const originalChildren = Array.from(button.childNodes).map((node) => node.cloneNode(true));
             button.disabled = true;
-            button.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
+            setButtonLoading(button);
 
             try {
                 const data = await toggleArrived(form);
                 if (data.success) {
                     setButtonState(button, data.arrived);
                 } else {
-                    button.innerHTML = originalHtml;
+                    restoreButtonChildren(button, originalChildren);
                     alert(gettext("An error occurred."));
                 }
             } catch (error) {
                 console.error("Failed to toggle arrived status", error);
-                button.innerHTML = originalHtml;
+                restoreButtonChildren(button, originalChildren);
                 alert(gettext("An error occurred."));
             } finally {
                 button.disabled = false;

--- a/teamshifts/static/teamshifts/members.js
+++ b/teamshifts/static/teamshifts/members.js
@@ -1,0 +1,54 @@
+function gettext(msgid) {
+    return typeof window.gettext === "function" ? window.gettext(msgid) : msgid;
+}
+
+/**
+ * @throws {Error} when the network request fails
+ */
+async function toggleArrived(form) {
+    const response = await fetch(form.action, {
+        method: "POST",
+        body: new FormData(form),
+        headers: {
+            "X-Requested-With": "XMLHttpRequest",
+        },
+    });
+    return response.json();
+}
+
+function setButtonState(button, arrived) {
+    if (arrived) {
+        button.className = "btn btn-sm btn-success";
+        button.innerHTML = `<i class="fa fa-check"></i> ${gettext("Arrived")}`;
+    } else {
+        button.className = "btn btn-sm btn-default";
+        button.innerHTML = `<i class="fa fa-times"></i> ${gettext("Not arrived")}`;
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".toggle-arrived-form").forEach((form) => {
+        form.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            const button = form.querySelector("button");
+            const originalHtml = button.innerHTML;
+            button.disabled = true;
+            button.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
+
+            try {
+                const data = await toggleArrived(form);
+                if (data.success) {
+                    setButtonState(button, data.arrived);
+                } else {
+                    button.innerHTML = originalHtml;
+                    alert(gettext("An error occurred."));
+                }
+            } catch (error) {
+                console.error("Failed to toggle arrived status", error);
+                button.innerHTML = originalHtml;
+            } finally {
+                button.disabled = false;
+            }
+        });
+    });
+});

--- a/teamshifts/templates/teamshifts/members.html
+++ b/teamshifts/templates/teamshifts/members.html
@@ -1,7 +1,12 @@
 {% extends "teamshifts/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load static %}
 
+{% block custom_header %}
+    {{ block.super }}
+    <script type="module" src="{% static 'teamshifts/members.js' %}"></script>
+{% endblock %}
 {% block title %}{% trans "Members" %} :: {{ request.event.name }}{% endblock %}
 
 {% block content %}
@@ -90,48 +95,4 @@
             </p>
         </div>
     {% endif %}
-
-    <script>
-        document.addEventListener("DOMContentLoaded", function() {
-            const forms = document.querySelectorAll('.toggle-arrived-form');
-            forms.forEach(form => {
-                form.addEventListener('submit', function(e) {
-                    e.preventDefault();
-                    const button = form.querySelector('button');
-                    const originalHtml = button.innerHTML;
-                    button.disabled = true;
-                    button.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
-
-                    fetch(form.action, {
-                        method: 'POST',
-                        body: new FormData(form),
-                        headers: {
-                            'X-Requested-With': 'XMLHttpRequest'
-                        }
-                    })
-                    .then(response => response.json())
-                    .then(data => {
-                        button.disabled = false;
-                        if (data.success) {
-                            if (data.arrived) {
-                                button.className = 'btn btn-sm btn-success';
-                                button.innerHTML = '<i class="fa fa-check"></i> ' + '{% trans "Arrived"|escapejs %}';
-                            } else {
-                                button.className = 'btn btn-sm btn-default';
-                                button.innerHTML = '<i class="fa fa-times"></i> ' + '{% trans "Not arrived"|escapejs %}';
-                            }
-                        } else {
-                            button.innerHTML = originalHtml;
-                            alert('{% trans "An error occurred."|escapejs %}');
-                        }
-                    })
-                    .catch(error => {
-                        button.disabled = false;
-                        button.innerHTML = originalHtml;
-                        console.error('Error:', error);
-                    });
-                });
-            });
-        });
-    </script>
 {% endblock %}


### PR DESCRIPTION
**Summary**

Fixes the "Arrived" toggle on the Members page (`/teamshifts/event/<org>/<event>/members/`) showing raw JSON instead of updating in place, when running with `DEBUG=False` (as on dev.eventyay.com).

**Root cause**

`members.html` implemented the toggle handler as an inline `<script>` block. The app's CSP middleware (`SecurityMiddleware`) only allows `'unsafe-inline'` in `script-src` when `DEBUG` (or `VITE_DEV_MODE`) is `True`. Under `DEBUG=False`, the browser silently blocks the inline script, so `event.preventDefault()` never runs, and clicking the toggle button falls back to a plain form submission — landing on the raw `JsonResponse` page instead of updating the
button in place.

**Changes**

- Added `teamshifts/static/teamshifts/members.js`, an external ES module handling the toggle-arrived AJAX request and button state update, following the same pattern as `apply.js` and `cfm_settings.js`.
- Removed the inline `<script>` block from `members.html` and load the new file via `{% block custom_header %}` + `{% static %}`, matching how other teamshifts templates load their JS.
- Used `window.gettext(...)` for the "Arrived" / "Not arrived" / error strings, matching the i18n pattern already used in other external JS files in the codebase (template `{% trans %}` tags aren't usable outside a Django template).


https://github.com/user-attachments/assets/0d1dddd4-5d31-454f-8e6e-f2f6bcb7e1df



**Note**
- No backend changes were needed; `MemberArrivedToggleView` already returns the correct JSON response.


Closes #78

## Summary by Sourcery

Ensure the Members page "Arrived" toggle works under CSP by moving its client-side logic into an external ES module and wiring it into the template.

New Features:
- Add a dedicated members.js ES module to handle the Members page arrived-toggle AJAX behavior and button state updates.

Enhancements:
- Load the new members.js script via the template’s custom_header block using the static files system, aligning the Members page with other teamshifts templates.
- Use window.gettext-based translations for arrived-toggle labels and error messages in the external JavaScript to preserve i18n support.