### PR TITLE
fix: align question toggle URL with application-form page path

### DIFF
--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -98,7 +98,7 @@ urlpatterns = [
         name="question_reorder",
     ),
     path(
-        "teamshifts/event/<orgslug:organizer>/<slug:event>/settings/<int:pk>/toggle/",
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/settings/application-form/<int:pk>/toggle/",
         views.QuestionToggleView.as_view(),
         name="question_toggle",
     ),


### PR DESCRIPTION
**Root cause:** The shared `questionToggles.js` uses a relative fetch URL (`${questionId}/toggle/`). On the orga CfP page this works because the page URL ends at `.../cfp/questions/` and the toggle endpoint sits at `.../cfp/questions/<pk>/toggle/`. But on teamshifts, the page URL is `.../settings/application-form/` while the toggle endpoint was at `.../settings/<pk>/toggle/` — so the relative resolution produced `.../settings/application-form/<pk>/toggle/` which didn't match any URL pattern → 404.

**Fix:** Moved the toggle URL pattern from `settings/<pk>/toggle/` to `settings/application-form/<pk>/toggle/` so the relative fetch resolves correctly.


https://github.com/user-attachments/assets/9ba3e68d-2b33-4cda-b1c9-fb0abeef1cae



Closes #72

## Summary by Sourcery

Bug Fixes:
- Correct question toggle URL on teamshifts settings page to prevent 404s when toggling questions via the shared frontend script.