### PR TITLE
fix: restore missing table cell in roles list causing edit/delete column misalignment

### DIFF
--- a/teamshifts/templates/teamshifts/roles.html
+++ b/teamshifts/templates/teamshifts/roles.html
@@ -24,7 +24,6 @@
                     <tr>
                         <th>{% trans "Role name" %}</th>
                         <th>{% trans "Description" %}</th>
-                        <th>{% trans "Applications" %}</th>
                         <th class='action-col-2'></th>
                     </tr>
                 </thead>

--- a/teamshifts/templates/teamshifts/roles.html
+++ b/teamshifts/templates/teamshifts/roles.html
@@ -24,6 +24,7 @@
                     <tr>
                         <th>{% trans "Role name" %}</th>
                         <th>{% trans "Description" %}</th>
+                        <th>{% trans "Applications" %}</th>
                         <th class='action-col-2'></th>
                     </tr>
                 </thead>
@@ -32,6 +33,7 @@
                         <tr>
                             <td><strong>{{ role.name }}</strong></td>
                             <td class='text-muted'>{{ role.description|default:"—" }}</td>
+                            <td></td>
                             <td class='text-right flip'>
                                 <a href='{% url "plugins:teamshifts:role_edit" organizer=request.organizer.slug event=request.event.slug pk=role.pk %}'
                                    class='btn btn-default btn-sm'>


### PR DESCRIPTION
The Team Roles table has 4 header columns (Role name, Description, Applications, actions) but the `feat/edit-team-role` PR only added 3 `<td>` per body row when it introduced the edit button. This caused the edit/delete buttons to render in the "Applications" column and the actual action column to be empty.

Added the missing empty `<td></td>` as the 3rd cell in each row so the 4-column body matches the 4-column header and the buttons land in the correct `action-col-2` slot.

<img width="2286" height="1275" alt="image" src="https://github.com/user-attachments/assets/0df08e4f-1e9d-4786-a1c3-0ac4356c25b8" />

## Summary by Sourcery

Bug Fixes:
- Add the missing empty table cell in each Team Role row to prevent edit/delete buttons from appearing under the Applications column.