### PR TITLE
feat: add bulk action confirmation dialogs and keep checkboxes always selectable

### DIFF
--- a/teamshifts/static/teamshifts/applications.js
+++ b/teamshifts/static/teamshifts/applications.js
@@ -55,27 +55,22 @@ function getBulkActionConfirmMessage(action) {
 }
 
 function setupBulkActions() {
-    const form = document.getElementById("bulk-action-form");
-    const actionInput = document.getElementById("bulk-action-input");
-
     document.querySelectorAll(".teamshifts-bulk-action-btn").forEach((button) => {
-        button.addEventListener("click", () => {
-            const action = button.dataset.action;
-            const selectedCount = document.querySelectorAll(".app-checkbox:checked").length;
+        button.addEventListener("click", (event) => {
+            event.preventDefault();
 
+            const selectedCount = document.querySelectorAll(".app-checkbox:checked").length;
             if (selectedCount === 0) {
                 window.alert(gettext("Please select at least one application."));
                 return;
             }
 
             window
-                .showConfirmDialog({ message: getBulkActionConfirmMessage(action) })
+                .showConfirmDialog({ message: getBulkActionConfirmMessage(button.value) })
                 .then((confirmed) => {
-                    if (!confirmed) {
-                        return;
+                    if (confirmed) {
+                        button.form.requestSubmit(button);
                     }
-                    actionInput.value = action;
-                    form.requestSubmit();
                 });
         });
     });

--- a/teamshifts/static/teamshifts/applications.js
+++ b/teamshifts/static/teamshifts/applications.js
@@ -41,8 +41,42 @@ function setupSelectAll() {
     }
 
     selectAll.addEventListener("change", () => {
-        document.querySelectorAll(".app-checkbox:not([disabled])").forEach((checkbox) => {
+        document.querySelectorAll(".app-checkbox").forEach((checkbox) => {
             checkbox.checked = selectAll.checked;
+        });
+    });
+}
+
+function getBulkActionConfirmMessage(action) {
+    if (action === "accept") {
+        return gettext("Are you sure you want to accept the selected applications? This may send emails to the applicants.");
+    }
+    return gettext("Are you sure you want to reject the selected applications? This may send emails to the applicants.");
+}
+
+function setupBulkActions() {
+    const form = document.getElementById("bulk-action-form");
+    const actionInput = document.getElementById("bulk-action-input");
+
+    document.querySelectorAll(".teamshifts-bulk-action-btn").forEach((button) => {
+        button.addEventListener("click", () => {
+            const action = button.dataset.action;
+            const selectedCount = document.querySelectorAll(".app-checkbox:checked").length;
+
+            if (selectedCount === 0) {
+                window.alert(gettext("Please select at least one application."));
+                return;
+            }
+
+            window
+                .showConfirmDialog({ message: getBulkActionConfirmMessage(action) })
+                .then((confirmed) => {
+                    if (!confirmed) {
+                        return;
+                    }
+                    actionInput.value = action;
+                    form.requestSubmit();
+                });
         });
     });
 }
@@ -50,4 +84,5 @@ function setupSelectAll() {
 document.addEventListener("DOMContentLoaded", () => {
     setupStatusDropdowns();
     setupSelectAll();
+    setupBulkActions();
 });

--- a/teamshifts/templates/teamshifts/applications.html
+++ b/teamshifts/templates/teamshifts/applications.html
@@ -37,10 +37,10 @@
     
     {% if applications %}
         <div class="pull-right">
-            <button type="button" class="btn btn-success teamshifts-bulk-action-btn" data-action="accept">
+            <button type="submit" form="bulk-action-form" name="action" value="accept" class="btn btn-success teamshifts-bulk-action-btn">
                 <span class="fa fa-check"></span> {% trans "Bulk Accept" %}
             </button>
-            <button type="button" class="btn btn-danger teamshifts-bulk-action-btn" data-action="reject">
+            <button type="submit" form="bulk-action-form" name="action" value="reject" class="btn btn-danger teamshifts-bulk-action-btn">
                 <span class="fa fa-times"></span> {% trans "Bulk Reject" %}
             </button>
         </div>
@@ -50,7 +50,6 @@
     {% if applications %}
         <form method="post" action="{% url 'plugins:teamshifts:application_bulk_action' organizer=request.organizer.slug event=request.event.slug %}" id="bulk-action-form">
             {% csrf_token %}
-            <input type="hidden" name="action" id="bulk-action-input" value="">
         </form>
         <div class="table-responsive">
             <table class="table table-hover table-quotas">

--- a/teamshifts/templates/teamshifts/applications.html
+++ b/teamshifts/templates/teamshifts/applications.html
@@ -37,10 +37,10 @@
     
     {% if applications %}
         <div class="pull-right">
-            <button type="submit" form="bulk-action-form" name="action" value="accept" class="btn btn-success">
+            <button type="button" class="btn btn-success teamshifts-bulk-action-btn" data-action="accept">
                 <span class="fa fa-check"></span> {% trans "Bulk Accept" %}
             </button>
-            <button type="submit" form="bulk-action-form" name="action" value="reject" class="btn btn-danger">
+            <button type="button" class="btn btn-danger teamshifts-bulk-action-btn" data-action="reject">
                 <span class="fa fa-times"></span> {% trans "Bulk Reject" %}
             </button>
         </div>
@@ -50,6 +50,7 @@
     {% if applications %}
         <form method="post" action="{% url 'plugins:teamshifts:application_bulk_action' organizer=request.organizer.slug event=request.event.slug %}" id="bulk-action-form">
             {% csrf_token %}
+            <input type="hidden" name="action" id="bulk-action-input" value="">
         </form>
         <div class="table-responsive">
             <table class="table table-hover table-quotas">
@@ -70,7 +71,7 @@
                     {% for app in applications %}
                         <tr>
                             <td class="teamshifts-checkbox-cell">
-                                <input type="checkbox" name="application_ids" value="{{ app.pk }}" form="bulk-action-form" class="app-checkbox" {% if app.status != 'pending' %}disabled{% endif %}>
+                                <input type="checkbox" name="application_ids" value="{{ app.pk }}" form="bulk-action-form" class="app-checkbox" aria-label="{% trans 'Select application' %}">
                             </td>
                             {% for val in app.dynamic_values %}
                                 <td>{{ val|default:"—" }}</td>

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -636,24 +636,24 @@ class BulkApplicationStatusView(PluginActiveMixin, EventPermissionRequiredMixin,
                 messages.warning(request, _("No applications selected."))
                 return redirect(reverse("plugins:teamshifts:applications", kwargs={"organizer": event.organizer.slug, "event": event.slug}))
 
+            new_status = ApplicationStatus.ACCEPTED if action == "accept" else ApplicationStatus.REJECTED
+
             apps = list(
                 TeamMemberApplication.objects.filter(
                     event=event,
                     pk__in=app_ids,
-                    status=ApplicationStatus.PENDING,
-                ).select_related("user")
+                )
+                .exclude(status=new_status)
+                .select_related("user")
             )
 
             if not apps:
-                messages.warning(request, _("None of the selected applications were in a pending state."))
+                messages.warning(request, _("The selected applications already have this status."))
                 return redirect(reverse("plugins:teamshifts:applications", kwargs={"organizer": event.organizer.slug, "event": event.slug}))
-
-            new_status = ApplicationStatus.ACCEPTED if action == "accept" else ApplicationStatus.REJECTED
 
             TeamMemberApplication.objects.filter(
                 event=event,
                 pk__in=[a.pk for a in apps],
-                status=ApplicationStatus.PENDING,
             ).update(status=new_status, updated_at=now())
 
             for app in apps:

--- a/tests/test_bulk_application_status.py
+++ b/tests/test_bulk_application_status.py
@@ -58,8 +58,17 @@ def pending_applications(event, team_role, django_user_model):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("action", "expected_status"),
+    [
+        ("accept", ApplicationStatus.ACCEPTED),
+        ("reject", ApplicationStatus.REJECTED),
+    ],
+)
 @patch("teamshifts.views.queue_lifecycle_email")
-def test_bulk_accept_updates_all_selected_pending_applications(mock_queue, client, event, team_role, pending_applications, orga_user, settings):
+def test_bulk_action_updates_all_selected_pending_applications(
+    mock_queue, action, expected_status, client, event, team_role, pending_applications, orga_user, settings
+):
     settings.SITE_URL = "https://testserver"
     client.force_login(orga_user)
 
@@ -68,7 +77,7 @@ def test_bulk_accept_updates_all_selected_pending_applications(mock_queue, clien
 
     tc = TestCase()
     with tc.captureOnCommitCallbacks(execute=True):
-        response = client.post(url, {"action": "accept", "application_ids": app_ids})
+        response = client.post(url, {"action": action, "application_ids": app_ids})
 
     expected_url = reverse("plugins:teamshifts:applications", kwargs={"organizer": event.organizer.slug, "event": event.slug})
     assert response.status_code == 302
@@ -77,27 +86,7 @@ def test_bulk_accept_updates_all_selected_pending_applications(mock_queue, clien
     with scope(event=event):
         for app in pending_applications:
             app.refresh_from_db()
-            assert app.status == ApplicationStatus.ACCEPTED
-    assert mock_queue.call_count == len(pending_applications)
-
-
-@pytest.mark.django_db
-@patch("teamshifts.views.queue_lifecycle_email")
-def test_bulk_reject_updates_all_selected_pending_applications(mock_queue, client, event, team_role, pending_applications, orga_user, settings):
-    settings.SITE_URL = "https://testserver"
-    client.force_login(orga_user)
-
-    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
-    app_ids = [str(a.pk) for a in pending_applications]
-
-    tc = TestCase()
-    with tc.captureOnCommitCallbacks(execute=True):
-        client.post(url, {"action": "reject", "application_ids": app_ids})
-
-    with scope(event=event):
-        for app in pending_applications:
-            app.refresh_from_db()
-            assert app.status == ApplicationStatus.REJECTED
+            assert app.status == expected_status
     assert mock_queue.call_count == len(pending_applications)
 
 
@@ -145,27 +134,22 @@ def test_bulk_action_skips_applications_already_in_target_status(mock_queue, cli
     with tc.captureOnCommitCallbacks(execute=True):
         client.post(url, {"action": "accept", "application_ids": app_ids})
 
+    # Only the two applications that were not already accepted should trigger a new email.
     assert mock_queue.call_count == len(pending_applications) - 1
 
 
 @pytest.mark.django_db
-def test_bulk_action_requires_selection(client, event, team_role, orga_user, settings):
-    settings.SITE_URL = "https://testserver"
-    client.force_login(orga_user)
-
-    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
-    response = client.post(url, {"action": "accept"})
-
-    assert response.status_code == 302
-
-
-@pytest.mark.django_db
-def test_bulk_action_rejects_invalid_action(client, event, team_role, pending_applications, orga_user, settings):
+def test_bulk_action_rejects_invalid_input(client, event, team_role, pending_applications, orga_user, settings):
     settings.SITE_URL = "https://testserver"
     client.force_login(orga_user)
 
     url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
     app_ids = [str(a.pk) for a in pending_applications]
-    response = client.post(url, {"action": "delete", "application_ids": app_ids})
 
+    # No applications selected: warns and redirects instead of erroring.
+    response = client.post(url, {"action": "accept"})
+    assert response.status_code == 302
+
+    # Unsupported action value: rejected outright.
+    response = client.post(url, {"action": "delete", "application_ids": app_ids})
     assert response.status_code == 400

--- a/tests/test_bulk_application_status.py
+++ b/tests/test_bulk_application_status.py
@@ -1,0 +1,171 @@
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+from django.urls import reverse
+from django_scopes import scope
+from eventyay.base.models import Team
+
+from teamshifts.models import ApplicationStatus, CallForTeamMembers, TeamMemberApplication, TeamRole
+
+
+@pytest.fixture
+def call_for_team_members(event):
+    with scope(event=event):
+        return CallForTeamMembers.objects.create(
+            event=event,
+            active=True,
+        )
+
+
+@pytest.fixture
+def team_role(event):
+    with scope(event=event):
+        return TeamRole.objects.create(event=event, name="Volunteer")
+
+
+@pytest.fixture
+def orga_user(event, user):
+    with scope(event=event):
+        team = Team.objects.create(
+            organizer=event.organizer,
+            name="Test Team",
+            can_change_event_settings=True,
+            all_events=True,
+        )
+        team.members.add(user)
+    return user
+
+
+def _make_applicant(django_user_model, email):
+    return django_user_model.objects.create_user(email=email, password="x")
+
+
+@pytest.fixture
+def pending_applications(event, team_role, django_user_model):
+    with scope(event=event):
+        apps = []
+        for i in range(3):
+            applicant = _make_applicant(django_user_model, f"applicant{i}@example.com")
+            apps.append(
+                TeamMemberApplication.objects.create(
+                    event=event,
+                    user=applicant,
+                    status=ApplicationStatus.PENDING,
+                )
+            )
+        return apps
+
+
+@pytest.mark.django_db
+@patch("teamshifts.views.queue_lifecycle_email")
+def test_bulk_accept_updates_all_selected_pending_applications(mock_queue, client, event, team_role, pending_applications, orga_user, settings):
+    settings.SITE_URL = "https://testserver"
+    client.force_login(orga_user)
+
+    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    app_ids = [str(a.pk) for a in pending_applications]
+
+    tc = TestCase()
+    with tc.captureOnCommitCallbacks(execute=True):
+        response = client.post(url, {"action": "accept", "application_ids": app_ids})
+
+    expected_url = reverse("plugins:teamshifts:applications", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    assert response.status_code == 302
+    assert response.url == expected_url
+
+    with scope(event=event):
+        for app in pending_applications:
+            app.refresh_from_db()
+            assert app.status == ApplicationStatus.ACCEPTED
+    assert mock_queue.call_count == len(pending_applications)
+
+
+@pytest.mark.django_db
+@patch("teamshifts.views.queue_lifecycle_email")
+def test_bulk_reject_updates_all_selected_pending_applications(mock_queue, client, event, team_role, pending_applications, orga_user, settings):
+    settings.SITE_URL = "https://testserver"
+    client.force_login(orga_user)
+
+    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    app_ids = [str(a.pk) for a in pending_applications]
+
+    tc = TestCase()
+    with tc.captureOnCommitCallbacks(execute=True):
+        client.post(url, {"action": "reject", "application_ids": app_ids})
+
+    with scope(event=event):
+        for app in pending_applications:
+            app.refresh_from_db()
+            assert app.status == ApplicationStatus.REJECTED
+    assert mock_queue.call_count == len(pending_applications)
+
+
+@pytest.mark.django_db
+@patch("teamshifts.views.queue_lifecycle_email")
+def test_bulk_action_allows_changing_already_decided_applications(mock_queue, client, event, team_role, pending_applications, orga_user, settings):
+    """Bulk actions must still work on applications that were already accepted/rejected,
+    so decisions can be revisited later (not just while pending)."""
+    settings.SITE_URL = "https://testserver"
+    client.force_login(orga_user)
+
+    with scope(event=event):
+        pending_applications[0].status = ApplicationStatus.REJECTED
+        pending_applications[0].save(update_fields=["status"])
+
+    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    app_ids = [str(a.pk) for a in pending_applications]
+
+    tc = TestCase()
+    with tc.captureOnCommitCallbacks(execute=True):
+        response = client.post(url, {"action": "accept", "application_ids": app_ids})
+
+    assert response.status_code == 302
+    with scope(event=event):
+        for app in pending_applications:
+            app.refresh_from_db()
+            assert app.status == ApplicationStatus.ACCEPTED
+    assert mock_queue.call_count == len(pending_applications)
+
+
+@pytest.mark.django_db
+@patch("teamshifts.views.queue_lifecycle_email")
+def test_bulk_action_skips_applications_already_in_target_status(mock_queue, client, event, team_role, pending_applications, orga_user, settings):
+    settings.SITE_URL = "https://testserver"
+    client.force_login(orga_user)
+
+    with scope(event=event):
+        pending_applications[0].status = ApplicationStatus.ACCEPTED
+        pending_applications[0].save(update_fields=["status"])
+
+    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    app_ids = [str(a.pk) for a in pending_applications]
+
+    tc = TestCase()
+    with tc.captureOnCommitCallbacks(execute=True):
+        client.post(url, {"action": "accept", "application_ids": app_ids})
+
+    assert mock_queue.call_count == len(pending_applications) - 1
+
+
+@pytest.mark.django_db
+def test_bulk_action_requires_selection(client, event, team_role, orga_user, settings):
+    settings.SITE_URL = "https://testserver"
+    client.force_login(orga_user)
+
+    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    response = client.post(url, {"action": "accept"})
+
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_bulk_action_rejects_invalid_action(client, event, team_role, pending_applications, orga_user, settings):
+    settings.SITE_URL = "https://testserver"
+    client.force_login(orga_user)
+
+    url = reverse("plugins:teamshifts:application_bulk_action", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    app_ids = [str(a.pk) for a in pending_applications]
+    response = client.post(url, {"action": "delete", "application_ids": app_ids})
+
+    assert response.status_code == 400


### PR DESCRIPTION
#### Summary

Adds confirmation dialogs to Bulk Accept/Reject buttons on the applications page and removes the disabled state from checkboxes so organizers can revisit decisions at any time.

#### Problem

Previously, once an application was accepted or rejected, its checkbox was greyed out and could not be included in bulk actions again. Additionally, bulk actions had no confirmation step, risking accidental mass status changes and email sends.

#### Changes

- **`applications.js`** — Added `setupBulkActions()` with `showConfirmDialog` before form submission; removed `:not([disabled])` filter from select-all logic.
- **`applications.html`** — Buttons changed to `type="button"` with JS-driven submission; removed `disabled` condition on checkboxes; added `aria-label` for accessibility; added hidden `action` input.
- **`views.py`** — `BulkApplicationStatusView` now accepts applications in any status, excluding only those already in the target status to avoid duplicate lifecycle emails.
- **`tests/test_bulk_application_status.py`** — 6 new tests covering bulk accept, reject, re-decision, same-status skip, empty selection, and invalid action.


https://github.com/user-attachments/assets/0118691d-0265-4d2a-bda0-156f3a59c184




#### Risk and Rollback

Low risk. The change is additive (confirmation UX) and loosens a restriction (checkbox availability). Rollback is a simple revert.


Closes #83 

## Summary by Sourcery

Add confirmation-driven bulk application status changes that work on previously decided applications while avoiding duplicate updates.

New Features:
- Add confirmation dialogs for bulk accept and reject actions on the applications page.
- Allow bulk actions to be applied to applications regardless of their current status, while skipping those already in the target status.

Enhancements:
- Keep application checkboxes always selectable and include them in select-all, improving flexibility for organizers.
- Adjust bulk action buttons and form wiring to use a hidden action field and better align with the new confirmation flow.
- Improve accessibility of application selection checkboxes with aria-labels.

Tests:
- Add integration-style tests covering bulk accept, reject, re-deciding applications, skipping already-updated applications, empty selections, and invalid actions.