### PR TITLE
fix: replace fragile ETA dispatch with periodic poller for scheduled emails

### DIFF
--- a/teamshifts/apps.py
+++ b/teamshifts/apps.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.db.models.signals import post_migrate
 from django.utils.translation import gettext_lazy as _
 
 from . import __version__
+
+logger = logging.getLogger(__name__)
 
 try:
     from eventyay.base.plugins import PluginConfig
@@ -42,4 +46,4 @@ class TeamShiftsApp(PluginConfig):
                 },
             )
         except Exception:
-            pass
+            logger.exception("[TeamShifts] Failed to register beat schedule for dispatch_scheduled_emails")

--- a/teamshifts/apps.py
+++ b/teamshifts/apps.py
@@ -1,3 +1,4 @@
+from django.db.models.signals import post_migrate
 from django.utils.translation import gettext_lazy as _
 
 from . import __version__
@@ -22,5 +23,25 @@ class TeamShiftsApp(PluginConfig):
         category = "FEATURE"
 
     def ready(self):
-        from . import signals  # NOQA
-        from . import tasks  # NOQA
+        from . import signals, tasks  # noqa: F401 — registers signal receivers and celery tasks
+
+        post_migrate.connect(self._ensure_beat_schedule, sender=self)
+
+    @staticmethod
+    def _ensure_beat_schedule(sender, **kwargs):
+        from django_celery_beat.models import IntervalSchedule, PeriodicTask
+
+        try:
+            schedule, _ = IntervalSchedule.objects.get_or_create(
+                every=60, period=IntervalSchedule.SECONDS
+            )
+            PeriodicTask.objects.update_or_create(
+                name="teamshifts-dispatch-scheduled-emails",
+                defaults={
+                    "task": "teamshifts.dispatch_scheduled_emails",
+                    "interval": schedule,
+                    "enabled": True,
+                },
+            )
+        except Exception:
+            pass

--- a/teamshifts/apps.py
+++ b/teamshifts/apps.py
@@ -32,9 +32,7 @@ class TeamShiftsApp(PluginConfig):
         from django_celery_beat.models import IntervalSchedule, PeriodicTask
 
         try:
-            schedule, _ = IntervalSchedule.objects.get_or_create(
-                every=60, period=IntervalSchedule.SECONDS
-            )
+            schedule, _ = IntervalSchedule.objects.get_or_create(every=60, period=IntervalSchedule.SECONDS)
             PeriodicTask.objects.update_or_create(
                 name="teamshifts-dispatch-scheduled-emails",
                 defaults={

--- a/teamshifts/services/email.py
+++ b/teamshifts/services/email.py
@@ -77,9 +77,8 @@ def queue_email(
 
 def _dispatch(event_id: int, queue_id: int, eta=None) -> None:
     if eta is not None:
-        transaction.on_commit(lambda: send_queued_email.apply_async(args=[event_id, queue_id], eta=eta))
-    else:
-        transaction.on_commit(lambda: send_queued_email.delay(event_id, queue_id))
+        return
+    transaction.on_commit(lambda: send_queued_email.delay(event_id, queue_id))
 
 
 def queue_lifecycle_email(application, role: str) -> TeamShiftsEmailQueue | None:

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -105,6 +105,7 @@ def teamshifts_mail_placeholders(sender, **kwargs):
 def dispatch_scheduled_emails(sender, **kwargs):
     try:
         from .tasks import dispatch_scheduled_emails_task
+
         dispatch_scheduled_emails_task()
     except Exception:
         logger.exception("[TeamShifts] Failed in dispatch_scheduled_emails")

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -1,11 +1,8 @@
 import logging
 
-from django.core.cache import cache
-from django.db import transaction
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django_scopes import scopes_disabled
 from eventyay.base.email import SimpleFunctionalMailTextPlaceholder
@@ -14,8 +11,7 @@ from eventyay.common.signals import periodic_task
 from eventyay.control.signals import event_dashboard_components, event_dashboard_widgets
 from eventyay.presale.signals import header_nav_tabs
 
-from .models import CallForTeamMembers, TeamShiftsEmailQueue
-from .tasks import send_queued_email
+from .models import CallForTeamMembers
 
 logger = logging.getLogger(__name__)
 
@@ -107,17 +103,8 @@ def teamshifts_mail_placeholders(sender, **kwargs):
 @receiver(periodic_task, dispatch_uid="teamshifts_dispatch_scheduled_emails")
 @scopes_disabled()
 def dispatch_scheduled_emails(sender, **kwargs):
-    MAIL_SEND_BATCH_SIZE = 50
-    with transaction.atomic():
-        due = list(
-            TeamShiftsEmailQueue.objects.filter(send_after__isnull=False, send_after__lte=now(), sent_at__isnull=True)
-            .select_for_update(skip_locked=True, of=("self",))
-            .order_by("pk")
-            .values("pk", "event_id")[:MAIL_SEND_BATCH_SIZE]
-        )
-    for item in due:
-        cache_key = f"teamshifts_mail_queue_{item['pk']}_enqueued"
-        if not cache.get(cache_key):
-            send_queued_email.delay(item["event_id"], item["pk"])
-            cache.set(cache_key, True, timeout=3600)
-            logger.info("[TeamShifts] Enqueued missed scheduled email queue %s", item["pk"])
+    try:
+        from .tasks import dispatch_scheduled_emails_task
+        dispatch_scheduled_emails_task()
+    except Exception:
+        logger.exception("[TeamShifts] Failed in dispatch_scheduled_emails")

--- a/teamshifts/tasks.py
+++ b/teamshifts/tasks.py
@@ -1,8 +1,10 @@
 import logging
 
 from celery.exceptions import MaxRetriesExceededError
+from django.core.cache import cache
+from django.db import transaction
 from django.utils.timezone import now
-from django_scopes import scope
+from django_scopes import scope, scopes_disabled
 from eventyay.base.email import get_email_context
 from eventyay.base.models import Event
 from eventyay.base.services.mail import SendMailException, mail
@@ -13,6 +15,31 @@ from i18nfield.strings import LazyI18nString
 from .models import TeamShiftsEmailQueue
 
 logger = logging.getLogger(__name__)
+
+SCHEDULED_EMAIL_BATCH_SIZE = 50
+
+
+@app.task(name="teamshifts.dispatch_scheduled_emails")
+def dispatch_scheduled_emails_task():
+    with scopes_disabled():
+        with transaction.atomic():
+            due = list(
+                TeamShiftsEmailQueue.objects.filter(
+                    send_after__isnull=False,
+                    send_after__lte=now(),
+                    sent_at__isnull=True,
+                )
+                .select_for_update(skip_locked=True)
+                .order_by("pk")
+                .values_list("pk", "event_id")[:SCHEDULED_EMAIL_BATCH_SIZE]
+            )
+
+    for queue_pk, event_id in due:
+        cache_key = f"teamshifts_mail_queue_{queue_pk}_enqueued"
+        if not cache.get(cache_key):
+            send_queued_email.delay(event_id, queue_pk)
+            cache.set(cache_key, True, timeout=300)
+            logger.info("[TeamShifts] Dispatched scheduled email queue %s", queue_pk)
 
 
 @app.task(
@@ -44,17 +71,7 @@ def send_queued_email(self, event_id: int, queue_id: int):
             if queue.sent_at:
                 return
             if queue.send_after and queue.send_after > now():
-                delay_seconds = max(int((queue.send_after - now()).total_seconds()), 1)
-                logger.info(
-                    "[TeamShifts] Queue %s not yet due (send_after=%s), rescheduling in %d seconds",
-                    queue_id,
-                    queue.send_after,
-                    delay_seconds,
-                )
-                send_queued_email.apply_async(
-                    args=[original_event_id, queue_id],
-                    countdown=delay_seconds,
-                )
+                logger.debug("[TeamShifts] Queue %s not yet due, skipping", queue_id)
                 return
             recipients = list(queue.recipients.select_related("user").all())
 

--- a/teamshifts/tasks.py
+++ b/teamshifts/tasks.py
@@ -36,9 +36,8 @@ def dispatch_scheduled_emails_task():
 
     for queue_pk, event_id in due:
         cache_key = f"teamshifts_mail_queue_{queue_pk}_enqueued"
-        if not cache.get(cache_key):
+        if cache.add(cache_key, True, timeout=300):
             send_queued_email.delay(event_id, queue_pk)
-            cache.set(cache_key, True, timeout=300)
             logger.info("[TeamShifts] Dispatched scheduled email queue %s", queue_pk)
 
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -142,24 +142,21 @@ def test_queue_email_send_after_persists(event, accepted_user):
 
 
 @pytest.mark.django_db
-def test_dispatch_uses_apply_async_when_eta_given(event, accepted_user):
-    """When send_after is provided, _dispatch must call apply_async with eta."""
+def test_dispatch_does_not_enqueue_when_eta_given(event, accepted_user):
+    """When send_after is provided, _dispatch returns early (periodic poller handles it)."""
     when = datetime.datetime(2099, 6, 1, tzinfo=datetime.UTC)
     with (
         patch("teamshifts.services.email.send_queued_email") as mock_task,
         patch("teamshifts.services.email.transaction.on_commit", side_effect=lambda fn: fn()),
     ):
-        queue = queue_email(
+        queue_email(
             event=event,
             subject="s",
             message="m",
             recipients=[accepted_user],
             send_after=when,
         )
-        mock_task.apply_async.assert_called_once()
-        _, kwargs = mock_task.apply_async.call_args
-        assert kwargs["eta"] == when
-        assert queue.pk in kwargs["args"]
+        mock_task.apply_async.assert_not_called()
         mock_task.delay.assert_not_called()
 
 
@@ -204,7 +201,7 @@ def test_dispatch_scheduled_emails_enqueues_due_queues(event):
             sent_at=now(),
         )
 
-    with patch("teamshifts.signals.send_queued_email") as mock_task:
+    with patch("teamshifts.tasks.send_queued_email") as mock_task:
         dispatch_scheduled_emails(sender=None)
 
     enqueued_queue_ids = {call.args[1] for call in mock_task.delay.call_args_list}

--- a/tests/test_email_tasks.py
+++ b/tests/test_email_tasks.py
@@ -43,22 +43,15 @@ def queue(event, django_user_model):
 
 
 @pytest.mark.django_db
-def test_send_after_in_future_reschedules(event, queue):
-    """When send_after > now, task reschedules via apply_async and does not send."""
+def test_send_after_in_future_skips(event, queue):
+    """When send_after > now, task returns early without sending or rescheduling."""
     with scope(event=event):
         queue.send_after = now() + timedelta(hours=1)
         queue.save(update_fields=["send_after"])
 
-    with (
-        patch("teamshifts.tasks.mail") as mock_mail,
-        patch.object(send_queued_email, "apply_async") as mock_apply,
-    ):
+    with patch("teamshifts.tasks.mail") as mock_mail:
         send_queued_email.run(event_id=event.pk, queue_id=queue.pk)
 
-    mock_apply.assert_called_once()
-    _, kwargs = mock_apply.call_args
-    assert kwargs["args"] == [event.pk, queue.pk]
-    assert kwargs["countdown"] >= 1
     mock_mail.assert_not_called()
 
 


### PR DESCRIPTION
#### Summary

Scheduled emails were never delivered on staging — they remained in the Outbox with Pending status indefinitely after `send_after` was reached. This fix replaces the fragile Celery ETA-based dispatch with a reliable periodic polling approach and registers an independent celery-beat task via `django_celery_beat.PeriodicTask`.

#### Problem

Two compounding failures prevented scheduled emails from sending:

1. **Celery ETA delivery is unreliable** — `apply_async(eta=send_after)` stores the task in Redis's sorted set. If the broker restarts or Redis evicts keys under memory pressure, ETA tasks are silently lost with no retry.

2. **The fallback signal receiver could be killed by upstream crashes** — `periodic_task.send()` (not `send_robust()`) means any exception in an earlier receiver (e.g. `process_scheduled_emails` re-raising on a bad `QueuedMail`) terminates the entire signal chain. The teamshifts receiver, registered later, never fires.

#### Changes

- **`services/email.py`**: `_dispatch(eta=...)` no longer enqueues an ETA task. Scheduled emails are persisted to DB and picked up by the periodic poller within 60 seconds of being due. Immediate emails (`eta=None`) still dispatch via `delay()` on commit — no change to lifecycle/transactional email delivery.

- **`tasks.py`**: Added `dispatch_scheduled_emails_task` — a standalone Celery task that queries overdue `TeamShiftsEmailQueue` rows and dispatches `send_queued_email` for each. Removed the self-reschedule loop (the task no longer calls `apply_async(countdown=...)` on itself). If called before `send_after`, the task simply returns.

- **`signals.py`**: The `periodic_task` signal receiver now delegates to `dispatch_scheduled_emails_task()` wrapped in try/except, so it cannot crash even if called, and cannot be crashed by upstream receiver failures.

- **`apps.py`**: Registers a `django_celery_beat.PeriodicTask` (60s interval) via `post_migrate` signal — gives the dispatch task its own independent beat schedule entry, completely decoupled from the `periodic_task` signal chain.

#### Regression check

- **Immediate emails** (lifecycle: accepted/rejected, compose without schedule): `send_after=None` → `_dispatch` calls `send_queued_email.delay()` on commit. Path unchanged.
- **Draft emails** (compose with `action=draft`): `dispatch=False` → nothing fires. Path unchanged.
- **Scheduled emails**: now handled by periodic poller instead of ETA. Latency is ≤60s after `send_after` vs "immediately at ETA" (acceptable trade-off for reliability).
- **Cache timeout reduced**: 5 minutes (was 1 hour) — faster recovery if a dispatch fails silently.


https://github.com/user-attachments/assets/b5750322-1cb3-4838-98cc-65035b1a253d



#### Risk and Rollback

Low risk. The only behavioral change is scheduled emails use periodic polling (≤60s latency) instead of Celery ETA (0s ideal, ∞ on failure). Immediate/transactional emails are completely unaffected. Rollback is a simple revert.


Closes #76

## Summary by Sourcery

Replace fragile ETA-based scheduling for TeamShifts emails with a periodic polling task driven by django-celery-beat, ensuring scheduled emails are reliably dispatched.

Bug Fixes:
- Ensure scheduled TeamShifts emails that are due are reliably dispatched instead of remaining pending when ETA tasks are lost or missed.

Enhancements:
- Introduce a dedicated Celery task that periodically polls for due scheduled emails in the TeamShifts email queue and dispatches them in small batches.
- Register a django-celery-beat periodic task after migrations to drive the scheduled email dispatcher independently of other periodic signal receivers.
- Harden the periodic signal receiver by delegating to the dispatcher task in a try/except block so upstream failures cannot prevent scheduled emails from being processed.
- Avoid rescheduling email-send tasks before their send-after time and reduce the enqueue deduplication cache window for faster recovery from silent failures.