### PR TITLE
fix: show clear error message when duplicate roles added to a shift

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -536,21 +536,12 @@ class ShiftForm(forms.ModelForm):
 
 
 class BaseShiftRoleFormSet(forms.BaseInlineFormSet):
-    def non_form_errors(self):
-        errors = super().non_form_errors()
-        if not errors:
-            return errors
-        return forms.utils.ErrorList([_("The same role cannot be added twice on the same shift.") if "duplicate" in str(e).lower() else e for e in errors])
+    def validate_unique(self):
+        pass
 
     def clean(self):
         super().clean()
         if any(self.errors):
-            for error_dict in self.errors:
-                if isinstance(error_dict, dict):
-                    for field_errors in error_dict.values():
-                        for error in field_errors.as_data() if hasattr(field_errors, "as_data") else []:
-                            if getattr(error, "code", None) == "unique":
-                                raise forms.ValidationError(_("The same role cannot be added twice on the same shift."))
             return
 
         roles = set()

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -536,9 +536,21 @@ class ShiftForm(forms.ModelForm):
 
 
 class BaseShiftRoleFormSet(forms.BaseInlineFormSet):
+    def non_form_errors(self):
+        errors = super().non_form_errors()
+        if not errors:
+            return errors
+        return forms.utils.ErrorList([_("The same role cannot be added twice on the same shift.") if "duplicate" in str(e).lower() else e for e in errors])
+
     def clean(self):
         super().clean()
         if any(self.errors):
+            for error_dict in self.errors:
+                if isinstance(error_dict, dict):
+                    for field_errors in error_dict.values():
+                        for error in field_errors.as_data() if hasattr(field_errors, "as_data") else []:
+                            if getattr(error, "code", None) == "unique":
+                                raise forms.ValidationError(_("The same role cannot be added twice on the same shift."))
             return
 
         roles = set()

--- a/teamshifts/static/teamshifts/shift_role_formset.js
+++ b/teamshifts/static/teamshifts/shift_role_formset.js
@@ -46,8 +46,6 @@ export function setupDynamicFormset() {
     });
 }
 
-// Delegated handler on #roles-body so cloned rows work without re-binding,
-// and clicks outside a role row are a no-op instead of throwing.
 export function bindRemoveRowHandler() {
     const rolesBody = document.getElementById("roles-body");
     if (!rolesBody) {
@@ -66,17 +64,31 @@ export function bindRemoveRowHandler() {
         }
 
         const deleteCheckbox = row.querySelector('.delete-checkbox input[type="checkbox"]');
-        if (deleteCheckbox) {
+        const idInput = row.querySelector('input[name$="-id"]');
+        const hasExistingRecord = idInput && idInput.value;
+
+        if (hasExistingRecord && deleteCheckbox) {
             deleteCheckbox.checked = true;
             row.style.display = "none";
         } else {
             row.remove();
+            const totalFormsInput = document.getElementById("id_roles-TOTAL_FORMS");
+            if (totalFormsInput) {
+                const newTotal = Math.max(0, parseInt(totalFormsInput.value, 10) - 1);
+                totalFormsInput.value = newTotal;
+                const remainingRows = rolesBody.querySelectorAll(".role-form-row");
+                remainingRows.forEach((r, idx) => {
+                    r.querySelectorAll("input, select, label, textarea").forEach((el) => {
+                        if (el.name) el.name = el.name.replace(/roles-\d+-/, `roles-${idx}-`);
+                        if (el.id) el.id = el.id.replace(/roles-\d+-/, `roles-${idx}-`);
+                        if (el.htmlFor) el.htmlFor = el.htmlFor.replace(/roles-\d+-/, `roles-${idx}-`);
+                    });
+                });
+            }
         }
     });
 }
 
-// Switches the roles table from the no-JS checkbox fallback to the
-// trash-icon-button UX, once this script has actually run (see teamshifts.css).
 export function markFormsetJsEnabled() {
     const rolesTable = document.getElementById("roles-table");
     if (rolesTable) {

--- a/teamshifts/templates/teamshifts/shift_create.html
+++ b/teamshifts/templates/teamshifts/shift_create.html
@@ -67,7 +67,7 @@
                 {{ formset.management_form }}
                 {% if formset.non_form_errors %}
                     <div class="alert alert-danger">
-                        {{ formset.non_form_errors }}
+                        {{ formset.non_form_errors|striptags }}
                     </div>
                 {% endif %}
                 <table class="table table-striped" id="roles-table">

--- a/teamshifts/templates/teamshifts/shift_create.html
+++ b/teamshifts/templates/teamshifts/shift_create.html
@@ -87,6 +87,9 @@
                                     {% if form.role.errors %}
                                         <div class="help-block">{{ form.role.errors|striptags }}</div>
                                     {% endif %}
+                                    {% if form.non_field_errors %}
+                                        <div class="help-block text-danger">{{ form.non_field_errors|striptags }}</div>
+                                    {% endif %}
                                 </td>
                                 <td class="{% if form.capacity.errors %}has-error{% endif %}">
                                     {{ form.capacity }}

--- a/teamshifts/templates/teamshifts/shift_edit.html
+++ b/teamshifts/templates/teamshifts/shift_edit.html
@@ -46,7 +46,7 @@
                 {{ formset.management_form }}
                 {% if formset.non_form_errors %}
                     <div class="alert alert-danger">
-                        {{ formset.non_form_errors }}
+                        {{ formset.non_form_errors|striptags }}
                     </div>
                 {% endif %}
                 <table class="table table-striped" id="roles-table">

--- a/teamshifts/templates/teamshifts/shift_edit.html
+++ b/teamshifts/templates/teamshifts/shift_edit.html
@@ -66,6 +66,9 @@
                                     {% if form.role.errors %}
                                         <div class="help-block">{{ form.role.errors|striptags }}</div>
                                     {% endif %}
+                                    {% if form.non_field_errors %}
+                                        <div class="help-block text-danger">{{ form.non_field_errors|striptags }}</div>
+                                    {% endif %}
                                 </td>
                                 <td class="{% if form.capacity.errors %}has-error{% endif %}">
                                     {{ form.capacity }}

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1203,6 +1203,7 @@ class ShiftCreateView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateV
             )
 
         ctx = self.get_context_data(form=form, formset=formset, has_locations=has_locations)
+        messages.error(request, _("We could not save your changes. See below for details."))
         return self.render_to_response(ctx)
 
 
@@ -1252,6 +1253,7 @@ class ShiftUpdateView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateV
                 messages.success(request, _("Shift updated successfully."))
                 return redirect("plugins:teamshifts:shift_edit", organizer=request.event.organizer.slug, event=request.event.slug, pk=self.shift.pk)
         else:
+            messages.error(request, _("We could not save your changes. See below for details."))
             ctx = self.get_context_data(form=form, formset=formset, has_locations=has_locations)
             return self.render_to_response(ctx)
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1242,7 +1242,10 @@ class ShiftUpdateView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateV
         form = ShiftForm(self.request.POST, event=self.request.event, instance=self.shift)
         formset = ShiftRoleFormSet(self.request.POST, prefix="roles", instance=self.shift, form_kwargs={"event": self.request.event})
 
-        if form.is_valid() and formset.is_valid():
+        form_valid = form.is_valid()
+        formset_valid = formset.is_valid()
+
+        if form_valid and formset_valid:
             with scope(event=request.event), transaction.atomic():
                 form.save()
                 formset.save()

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1249,8 +1249,8 @@ class ShiftUpdateView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateV
                 messages.success(request, _("Shift updated successfully."))
                 return redirect("plugins:teamshifts:shift_edit", organizer=request.event.organizer.slug, event=request.event.slug, pk=self.shift.pk)
         else:
-            messages.error(request, _("We could not save your changes. See below for details."))
-            return self.get(request, form=form, formset=formset, has_locations=has_locations)
+            ctx = self.get_context_data(form=form, formset=formset, has_locations=has_locations)
+            return self.render_to_response(ctx)
 
 
 class ShiftDeleteView(PluginActiveMixin, EventPermissionRequiredMixin, DeleteView):


### PR DESCRIPTION
Closes #86

#### Summary

Duplicate role validation now shows inline errors on both the shift create and edit forms, removes the generic top-level alert from the edit form, and properly handles new role row removal in the formset JS.

#### What Changed

**`forms.py`**

- `BaseShiftRoleFormSet.validate_unique()` overridden with `pass` to suppress Django's generic unique constraint error (which strips `cleaned_data` and prevents our own detection)
- `BaseShiftRoleFormSet.clean()` detects duplicate roles and raises: "The same role cannot be added twice on the same shift."

**`views.py`**

- `ShiftUpdateView.post`: evaluate `form.is_valid()` and `formset.is_valid()` independently so both populate errors even if one fails
- Removed the generic `messages.error()` top-level alert — errors now show inline
- Re-render uses `self.get_context_data()` + `self.render_to_response()` instead of `self.get()` to preserve the invalid form/formset in context

**`shift_create.html` / `shift_edit.html`**

- Added `{% if form.non_field_errors %}` rendering in the role row template so model-level unique constraint errors display inline below the duplicate role

**`shift_role_formset.js`**

- When removing a new role row (no saved DB record), the row is removed from DOM entirely and remaining rows are reindexed — prevents deleted roles from reappearing on validation failure re-render
- Existing saved rows still use the DELETE checkbox + hide approach

#### Why `pass` in `validate_unique`

Django's `validate_unique()` deletes `cleaned_data` from duplicate forms before raising `ValidationError`. If we catch the exception, `clean()` can no longer see role values to detect duplicates. Since the model has only one `unique_together` (`shift`, `role`), suppressing it is safe — our `clean()` covers that case with a better message. On the edit form, the model constraint still fires as a fallback and its error is now rendered inline.


https://github.com/user-attachments/assets/b11e1180-c971-4fd3-a654-0c98d047fef6

#### Testing

1. Go to TeamShifts → Shifts → Create or Edit a shift
2. Add two rows with the same role
3. Click Save
4. Error appears inline in the Roles Needed panel
5. On the edit form, no top-level generic alert is shown

## Summary by Sourcery

Improve validation feedback when duplicate roles are added to a shift.

Bug Fixes:
- Replace Django’s generic duplicate-role validation message with a clear inline error explaining that the same role cannot be added twice on the same shift.

Enhancements:
- Normalize non-form errors in the shift role formset to consistently surface the user-friendly duplicate-role message when uniqueness validation is triggered.