### PR TITLE
fix: use event timezone for date-time pickers instead of browser time

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -1,4 +1,7 @@
+from zoneinfo import ZoneInfo
+
 from django import forms
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 from django_scopes import scopes_disabled
@@ -37,11 +40,17 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             "deadline": SplitDateTimePickerWidget(),
             "title": forms.TextInput(attrs={"class": "form-control"}),
         }
+        help_texts = {
+            "deadline": _("Time is interpreted in the event timezone."),
+        }
 
     def __init__(self, *args, locales=None, **kwargs):
+        self._event = kwargs.pop("event", None)
         super().__init__(*args, **kwargs)
         if locales:
             self.fields["description"].widget.enabled_locales = locales
+        if self._event and not self.initial.get("deadline"):
+            self.initial["deadline"] = timezone.localtime(timezone.now(), ZoneInfo(self._event.timezone))
 
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
@@ -360,13 +369,18 @@ class EmailComposeForm(forms.Form):
         self.fields["send_after"] = forms.DateTimeField(
             required=False,
             label=_("Schedule for later"),
-            help_text=_("Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time."),
+            help_text=_(
+                "Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time. "
+                "Time is interpreted in the event timezone."
+            ),
             widget=forms.DateTimeInput(
                 attrs={"class": "form-control", "type": "datetime-local"},
                 format="%Y-%m-%dT%H:%M",
             ),
             input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
         )
+        if self._event:
+            self.fields["send_after"].initial = timezone.localtime(timezone.now(), ZoneInfo(self._event.timezone))
 
 
 class EmailQueueEditForm(forms.ModelForm):
@@ -379,6 +393,9 @@ class EmailQueueEditForm(forms.ModelForm):
                 format="%Y-%m-%dT%H:%M",
             ),
         }
+        help_texts = {
+            "send_after": _("Time is interpreted in the event timezone."),
+        }
 
     def __init__(self, *args, event=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -387,6 +404,8 @@ class EmailQueueEditForm(forms.ModelForm):
             locales = list(event.settings.get("locales") or [event.settings.locale])
             for field_name in ("subject", "message"):
                 self.fields[field_name].widget.enabled_locales = locales
+            if not self.instance.pk or not self.instance.send_after:
+                self.fields["send_after"].initial = timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
         self.fields["send_after"].input_formats = [
             "%Y-%m-%dT%H:%M",
             "%Y-%m-%d %H:%M:%S",
@@ -460,6 +479,10 @@ class ShiftForm(forms.ModelForm):
             "location": forms.Select(attrs={"class": "form-control"}),
             "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
         }
+        help_texts = {
+            "start_time": _("Time is interpreted in the event timezone."),
+            "end_time": _("Time is interpreted in the event timezone."),
+        }
 
     def __init__(self, *args, event=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -470,6 +493,13 @@ class ShiftForm(forms.ModelForm):
             from django_scopes import scopes_disabled
 
             from .models import ShiftLocation
+
+            if not self.instance.pk:
+                now_local = timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
+                if not self.initial.get("start_time"):
+                    self.initial["start_time"] = now_local
+                if not self.initial.get("end_time"):
+                    self.initial["end_time"] = now_local
 
             with scopes_disabled():
                 self.fields["location"].queryset = ShiftLocation.objects.filter(event=event)

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -22,6 +22,16 @@ from .models import (
     normalize_field_order,
 )
 
+EVENT_TZ_HELP = _("Time is interpreted in the event timezone.")
+
+
+def get_event_local_now(event):
+    return timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
+
+
+def format_datetime_local(dt):
+    return f"{dt:%Y-%m-%dT%H:%M}"
+
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):
     class Meta:
@@ -41,7 +51,7 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             "title": forms.TextInput(attrs={"class": "form-control"}),
         }
         help_texts = {
-            "deadline": _("Time is interpreted in the event timezone."),
+            "deadline": EVENT_TZ_HELP,
         }
 
     def __init__(self, *args, locales=None, **kwargs):
@@ -50,7 +60,7 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
         if locales:
             self.fields["description"].widget.enabled_locales = locales
         if self._event and not self.initial.get("deadline"):
-            self.initial["deadline"] = timezone.localtime(timezone.now(), ZoneInfo(self._event.timezone))
+            self.initial["deadline"] = get_event_local_now(self._event)
 
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
@@ -380,7 +390,7 @@ class EmailComposeForm(forms.Form):
             input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
         )
         if self._event:
-            self.fields["send_after"].initial = timezone.localtime(timezone.now(), ZoneInfo(self._event.timezone))
+            self.fields["send_after"].initial = format_datetime_local(get_event_local_now(self._event))
 
 
 class EmailQueueEditForm(forms.ModelForm):
@@ -394,7 +404,7 @@ class EmailQueueEditForm(forms.ModelForm):
             ),
         }
         help_texts = {
-            "send_after": _("Time is interpreted in the event timezone."),
+            "send_after": EVENT_TZ_HELP,
         }
 
     def __init__(self, *args, event=None, **kwargs):
@@ -405,7 +415,7 @@ class EmailQueueEditForm(forms.ModelForm):
             for field_name in ("subject", "message"):
                 self.fields[field_name].widget.enabled_locales = locales
             if not self.instance.pk or not self.instance.send_after:
-                self.fields["send_after"].initial = timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
+                self.fields["send_after"].initial = format_datetime_local(get_event_local_now(event))
         self.fields["send_after"].input_formats = [
             "%Y-%m-%dT%H:%M",
             "%Y-%m-%d %H:%M:%S",
@@ -480,8 +490,8 @@ class ShiftForm(forms.ModelForm):
             "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
         }
         help_texts = {
-            "start_time": _("Time is interpreted in the event timezone."),
-            "end_time": _("Time is interpreted in the event timezone."),
+            "start_time": EVENT_TZ_HELP,
+            "end_time": EVENT_TZ_HELP,
         }
 
     def __init__(self, *args, event=None, **kwargs):
@@ -495,7 +505,7 @@ class ShiftForm(forms.ModelForm):
             from .models import ShiftLocation
 
             if not self.instance.pk:
-                now_local = timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
+                now_local = format_datetime_local(get_event_local_now(event))
                 if not self.initial.get("start_time"):
                     self.initial["start_time"] = now_local
                 if not self.initial.get("end_time"):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -99,7 +99,7 @@ class CFMSettingsView(PluginActiveMixin, EventPermissionRequiredMixin, View):
 
     def get(self, request, *args, **kwargs):
         cfm = self._get_cfm()
-        form = CallForTeamMembersSettingsForm(instance=cfm, locales=request.event.settings.locales)
+        form = CallForTeamMembersSettingsForm(instance=cfm, locales=request.event.settings.locales, event=request.event)
 
         description = cfm.description.data if cfm.description else {}
         if not isinstance(description, dict):
@@ -112,7 +112,7 @@ class CFMSettingsView(PluginActiveMixin, EventPermissionRequiredMixin, View):
 
     def post(self, request, *args, **kwargs):
         cfm = self._get_cfm()
-        form = CallForTeamMembersSettingsForm(request.POST, instance=cfm, locales=request.event.settings.locales)
+        form = CallForTeamMembersSettingsForm(request.POST, instance=cfm, locales=request.event.settings.locales, event=request.event)
         if form.is_valid():
             with scope(event=request.event):
                 form.save()


### PR DESCRIPTION
#### Summary

Date/time pickers across TeamShifts now default to the event's configured timezone instead of the browser's local time, and display help text clarifying which timezone is used.

#### What Changed

**`forms.py`:**

- Added `get_event_local_now(event)` helper to centralize "current time in event timezone" logic
- Added `format_datetime_local(dt)` helper to consistently format datetimes for `datetime-local` HTML inputs
- Added `EVENT_TZ_HELP` shared constant for the timezone help text string
- `CallForTeamMembersSettingsForm`: accepts `event` kwarg, adds help text on deadline, pre-fills with event-local now when no existing value
- `EmailComposeForm`: pre-fills `send_after` with event-local now, help text includes timezone note
- `EmailQueueEditForm`: adds `help_texts["send_after"]`, pre-fills when creating a new queue item
- `ShiftForm`: adds `help_texts` for `start_time` and `end_time`, pre-fills both on new shift creation

**`views.py`:**

- `CFMSettingsView` form instantiations now pass `event=request.event` so the deadline can be pre-filled




https://github.com/user-attachments/assets/6afd816d-4963-4206-94b9-cecb4c0874d3

Closes #92

## Summary by Sourcery

Align date-time form fields with the event timezone instead of the browser/local timezone for team shifts and email scheduling.

Bug Fixes:
- Ensure call-for-team-members deadline, email scheduling, and shift times are interpreted and defaulted in the event timezone rather than the user’s browser timezone.

Enhancements:
- Add contextual help text to deadline, send-after, and shift time fields to clarify that times use the event timezone.
- Pre-fill deadline, email send-after, and shift start/end fields with the current time in the event timezone when creating new records.