### PR TITLE
fix: remove email schedule date pre-filling and correct send redirect

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -389,8 +389,6 @@ class EmailComposeForm(forms.Form):
             ),
             input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
         )
-        if self._event:
-            self.fields["send_after"].initial = format_datetime_local(get_event_local_now(self._event))
 
 
 class EmailQueueEditForm(forms.ModelForm):
@@ -414,8 +412,6 @@ class EmailQueueEditForm(forms.ModelForm):
             locales = list(event.settings.get("locales") or [event.settings.locale])
             for field_name in ("subject", "message"):
                 self.fields[field_name].widget.enabled_locales = locales
-            if not self.instance.pk or not self.instance.send_after:
-                self.fields["send_after"].initial = format_datetime_local(get_event_local_now(event))
         self.fields["send_after"].input_formats = [
             "%Y-%m-%dT%H:%M",
             "%Y-%m-%d %H:%M:%S",

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -879,6 +879,21 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
                 )
                 % {"count": len(recipients)},
             )
+        elif action == "send":
+            messages.success(
+                self.request,
+                ngettext(
+                    "Email sent to %(count)d recipient.",
+                    "Email sent to %(count)d recipients.",
+                    len(recipients),
+                )
+                % {"count": len(recipients)},
+            )
+            return redirect(
+                "plugins:teamshifts:email_sent",
+                organizer=self.request.organizer.slug,
+                event=event.slug,
+            )
         else:
             messages.success(
                 self.request,
@@ -889,6 +904,7 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
                 )
                 % {"count": len(recipients)},
             )
+
         return redirect(
             "plugins:teamshifts:email_outbox",
             organizer=self.request.organizer.slug,


### PR DESCRIPTION
Resolves #96

## Summary by Sourcery

Adjust email sending flow and scheduling defaults for teamshifts email actions.

Bug Fixes:
- Show a specific success message and redirect to the email sent confirmation page after immediate send actions instead of always returning to the outbox.
- Stop automatically pre-filling the email schedule date/time field with the current event time, allowing truly unscheduled or manually scheduled sends.