### PR TITLE
fix: remove email pre-fill, show event timezone in help text, and redirect Send to sent view

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -389,8 +389,6 @@ class EmailComposeForm(forms.Form):
             ),
             input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
         )
-        if self._event:
-            self.fields["send_after"].initial = format_datetime_local(get_event_local_now(self._event))
 
 
 class EmailQueueEditForm(forms.ModelForm):
@@ -414,8 +412,6 @@ class EmailQueueEditForm(forms.ModelForm):
             locales = list(event.settings.get("locales") or [event.settings.locale])
             for field_name in ("subject", "message"):
                 self.fields[field_name].widget.enabled_locales = locales
-            if not self.instance.pk or not self.instance.send_after:
-                self.fields["send_after"].initial = format_datetime_local(get_event_local_now(event))
         self.fields["send_after"].input_formats = [
             "%Y-%m-%dT%H:%M",
             "%Y-%m-%d %H:%M:%S",

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -1,7 +1,4 @@
-from zoneinfo import ZoneInfo
-
 from django import forms
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 from django_scopes import scopes_disabled
@@ -23,14 +20,6 @@ from .models import (
 )
 
 EVENT_TZ_HELP = _("Time is interpreted in the event timezone.")
-
-
-def get_event_local_now(event):
-    return timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
-
-
-def format_datetime_local(dt):
-    return f"{dt:%Y-%m-%dT%H:%M}"
 
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):
@@ -59,8 +48,6 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if locales:
             self.fields["description"].widget.enabled_locales = locales
-        if self._event and not self.initial.get("deadline"):
-            self.initial["deadline"] = get_event_local_now(self._event)
 
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
@@ -499,13 +486,6 @@ class ShiftForm(forms.ModelForm):
             from django_scopes import scopes_disabled
 
             from .models import ShiftLocation
-
-            if not self.instance.pk:
-                now_local = format_datetime_local(get_event_local_now(event))
-                if not self.initial.get("start_time"):
-                    self.initial["start_time"] = now_local
-                if not self.initial.get("end_time"):
-                    self.initial["end_time"] = now_local
 
             with scopes_disabled():
                 self.fields["location"].queryset = ShiftLocation.objects.filter(event=event)

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -1,4 +1,7 @@
+from zoneinfo import ZoneInfo
+
 from django import forms
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 from django_scopes import scopes_disabled
@@ -20,6 +23,14 @@ from .models import (
 )
 
 EVENT_TZ_HELP = _("Time is interpreted in the event timezone.")
+
+
+def get_event_local_now(event):
+    return timezone.localtime(timezone.now(), ZoneInfo(event.timezone))
+
+
+def format_datetime_local(dt):
+    return f"{dt:%Y-%m-%dT%H:%M}"
 
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):
@@ -48,6 +59,8 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if locales:
             self.fields["description"].widget.enabled_locales = locales
+        if self._event and not self.initial.get("deadline"):
+            self.initial["deadline"] = get_event_local_now(self._event)
 
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
@@ -486,6 +499,13 @@ class ShiftForm(forms.ModelForm):
             from django_scopes import scopes_disabled
 
             from .models import ShiftLocation
+
+            if not self.instance.pk:
+                now_local = format_datetime_local(get_event_local_now(event))
+                if not self.initial.get("start_time"):
+                    self.initial["start_time"] = now_local
+                if not self.initial.get("end_time"):
+                    self.initial["end_time"] = now_local
 
             with scopes_disabled():
                 self.fields["location"].queryset = ShiftLocation.objects.filter(event=event)

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -22,7 +22,9 @@ from .models import (
     normalize_field_order,
 )
 
-EVENT_TZ_HELP = _("Time is interpreted in the event timezone.")
+
+def get_tz_help(event):
+    return _("Times are in the event timezone: %(tz)s.") % {"tz": event.timezone}
 
 
 def get_event_local_now(event):
@@ -50,17 +52,17 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             "deadline": SplitDateTimePickerWidget(),
             "title": forms.TextInput(attrs={"class": "form-control"}),
         }
-        help_texts = {
-            "deadline": EVENT_TZ_HELP,
-        }
+        help_texts = {}
 
     def __init__(self, *args, locales=None, **kwargs):
         self._event = kwargs.pop("event", None)
         super().__init__(*args, **kwargs)
         if locales:
             self.fields["description"].widget.enabled_locales = locales
-        if self._event and not self.initial.get("deadline"):
-            self.initial["deadline"] = get_event_local_now(self._event)
+        if self._event:
+            self.fields["deadline"].help_text = get_tz_help(self._event)
+            if not self.initial.get("deadline"):
+                self.initial["deadline"] = get_event_local_now(self._event)
 
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
@@ -379,12 +381,14 @@ class EmailComposeForm(forms.Form):
         self.fields["send_after"] = forms.DateTimeField(
             required=False,
             label=_("Schedule for later"),
-            help_text=_(
-                "Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time. "
-                "Time is interpreted in the event timezone."
-            ),
+            help_text=_("Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time. %(tz)s")
+            % {"tz": get_tz_help(self._event) if self._event else ""},
             widget=forms.DateTimeInput(
-                attrs={"class": "form-control", "type": "datetime-local"},
+                attrs={
+                    "class": "form-control",
+                    "type": "datetime-local",
+                    **({"data-schedule-datetime": "1", "data-event-timezone": self._event.timezone} if self._event else {}),
+                },
                 format="%Y-%m-%dT%H:%M",
             ),
             input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
@@ -401,9 +405,7 @@ class EmailQueueEditForm(forms.ModelForm):
                 format="%Y-%m-%dT%H:%M",
             ),
         }
-        help_texts = {
-            "send_after": EVENT_TZ_HELP,
-        }
+        help_texts = {}
 
     def __init__(self, *args, event=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -412,6 +414,13 @@ class EmailQueueEditForm(forms.ModelForm):
             locales = list(event.settings.get("locales") or [event.settings.locale])
             for field_name in ("subject", "message"):
                 self.fields[field_name].widget.enabled_locales = locales
+            self.fields["send_after"].help_text = get_tz_help(event)
+            self.fields["send_after"].widget.attrs.update(
+                {
+                    "data-schedule-datetime": "1",
+                    "data-event-timezone": event.timezone,
+                }
+            )
         self.fields["send_after"].input_formats = [
             "%Y-%m-%dT%H:%M",
             "%Y-%m-%d %H:%M:%S",
@@ -485,10 +494,7 @@ class ShiftForm(forms.ModelForm):
             "location": forms.Select(attrs={"class": "form-control"}),
             "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
         }
-        help_texts = {
-            "start_time": EVENT_TZ_HELP,
-            "end_time": EVENT_TZ_HELP,
-        }
+        help_texts = {}
 
     def __init__(self, *args, event=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -496,6 +502,8 @@ class ShiftForm(forms.ModelForm):
         self.fields["start_time"].input_formats = ["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"]
         self.fields["end_time"].input_formats = self.fields["start_time"].input_formats
         if event is not None:
+            self.fields["start_time"].help_text = get_tz_help(event)
+            self.fields["end_time"].help_text = get_tz_help(event)
             from django_scopes import scopes_disabled
 
             from .models import ShiftLocation

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -381,8 +381,8 @@ class EmailComposeForm(forms.Form):
         self.fields["send_after"] = forms.DateTimeField(
             required=False,
             label=_("Schedule for later"),
-            help_text=_("Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time. %(tz)s")
-            % {"tz": get_tz_help(self._event) if self._event else ""},
+            help_text=_("Leave empty to send immediately. Otherwise the message stays in the outbox until the scheduled time.")
+            + (f" {get_tz_help(self._event)}" if self._event else ""),
             widget=forms.DateTimeInput(
                 attrs={
                     "class": "form-control",

--- a/teamshifts/static/teamshifts/schedule_datetime.js
+++ b/teamshifts/static/teamshifts/schedule_datetime.js
@@ -1,0 +1,27 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("[data-schedule-datetime]").forEach((input) => {
+    const timeZone = input.dataset.eventTimezone;
+    if (!timeZone) return;
+
+    input.addEventListener("focus", () => {
+      if (!input.value) {
+        input.value = formatNowInTimeZone(timeZone);
+      }
+    }, { once: true });
+  });
+});
+
+function formatNowInTimeZone(timeZone) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date());
+
+  const lookup = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  return `${lookup.year}-${lookup.month}-${lookup.day}T${lookup.hour}:${lookup.minute}`;
+}

--- a/teamshifts/templates/teamshifts/emails/compose.html
+++ b/teamshifts/templates/teamshifts/emails/compose.html
@@ -1,6 +1,12 @@
 {% extends "teamshifts/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load static %}
+
+{% block custom_header %}
+  {{ block.super }}
+  <script type="module" src="{% static 'teamshifts/schedule_datetime.js' %}"></script>
+{% endblock %}
 
 {% block title %}{% trans "Compose email" %} :: {{ request.event.name }}{% endblock %}
 

--- a/teamshifts/templates/teamshifts/emails/outbox_form.html
+++ b/teamshifts/templates/teamshifts/emails/outbox_form.html
@@ -1,6 +1,12 @@
 {% extends "teamshifts/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load static %}
+
+{% block custom_header %}
+  {{ block.super }}
+  <script type="module" src="{% static 'teamshifts/schedule_datetime.js' %}"></script>
+{% endblock %}
 
 {% block title %}{% trans "Edit email" %} :: {{ request.event.name }}{% endblock %}
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -883,11 +883,17 @@ class EmailComposeView(PluginActiveMixin, EventPermissionRequiredMixin, FormView
             messages.success(
                 self.request,
                 ngettext(
-                    "Email queued for %(count)d recipient.",
-                    "Email queued for %(count)d recipients.",
+                    "Email sent to %(count)d recipient.",
+                    "Email sent to %(count)d recipients.",
                     len(recipients),
                 )
                 % {"count": len(recipients)},
+            )
+        if action == "send" and not send_after:
+            return redirect(
+                "plugins:teamshifts:email_sent",
+                organizer=self.request.organizer.slug,
+                event=event.slug,
             )
         return redirect(
             "plugins:teamshifts:email_outbox",


### PR DESCRIPTION
#### Summary

Fixes email compose and outbox edit forms: removes auto-scheduling on page load, shows the actual event timezone in help text, pre-fills the event-local time only on field focus, and redirects the Send button to the sent view.

#### What Changed

**`forms.py`**
- Removed `send_after` server-side pre-fill from `EmailComposeForm` and `EmailQueueEditForm` — fields now start empty
- Replaced static "Time is interpreted in the event timezone." help text with dynamic `get_tz_help(event)` that shows the actual timezone name (e.g. "Times are in the event timezone: Asia/Kolkata.")
- Added `data-schedule-datetime` and `data-event-timezone` widget attrs on `send_after` fields for the JS focus handler
- Updated all datetime help texts across shift, CFM deadline, and email forms

**`schedule_datetime.js`** (new)
- On first focus of any `[data-schedule-datetime]` input, fills with current time in the event timezone using `Intl.DateTimeFormat`
- Field stays empty on load — no silent scheduling

**`views.py`**
- Send button (`action=send` without schedule) now redirects to the sent view instead of outbox
- Success message updated to "Email sent to X recipients"

**Templates**
- `compose.html` and `outbox_form.html` load `schedule_datetime.js`

#### Testing

1. Open email compose → "Schedule for later" field is empty
2. Click the field → pre-fills with current event-local time
3. Help text shows actual timezone name
4. Click "Send" without schedule → email dispatches, redirects to sent view
5. Click "Send to outbox" → email queued, stays in outbox

Close #96


https://github.com/user-attachments/assets/985bee89-014b-4b64-b1af-904b8eec6a41



## Summary by Sourcery

Adjust email scheduling UX to avoid auto-filled send times and improve timezone clarity, and update post-send navigation.

New Features:
- Add client-side behavior that fills schedule datetime fields with the current event-local time on first focus instead of on page load.

Bug Fixes:
- Stop pre-filling email scheduling fields on the server so messages are not silently scheduled without user intent.
- Ensure the event timezone name is shown explicitly in datetime help texts across email, shift, and call-for-members forms.
- Redirect immediate email sends to the sent view instead of the outbox to reflect their actual state.

Enhancements:
- Attach event timezone metadata to scheduling inputs and load a dedicated script on compose and outbox forms to drive the new focus behavior.
- Unify and clarify datetime help text messaging across relevant forms to emphasize event-local times.