### PR TITLE
ci: trigger workflows on dev branch

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,12 +2,12 @@ name: Code Style
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, dev ]
     paths-ignore:
       - 'teamshifts/locale/**'
       - 'teamshifts/static/**'
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, dev ]
     paths-ignore:
       - 'teamshifts/locale/**'
       - 'teamshifts/static/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, dev]
     paths-ignore:
       - "teamshifts/locale/**"
   pull_request:
-    branches: [main, master]
+    branches: [main, dev]
     paths-ignore:
       - "teamshifts/locale/**"
 


### PR DESCRIPTION
#### Changes
Replaced `master` with `dev` in both `push.branches` and `pull_request.branches` in both workflow files

#### What is it needed for?
Once this lands in `dev`, all PRs targeting `dev` will trigger CI again

## Summary by Sourcery

CI:
- Adjust style and test GitHub Actions to trigger on pushes and pull requests targeting the dev branch alongside main.