### PR TITLE
fix: renumber conflicting migration 0015 to 0016

### DIFF
--- a/teamshifts/migrations/0016_shiftassignment_role.py
+++ b/teamshifts/migrations/0016_shiftassignment_role.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("teamshifts", "0014_teamrole_is_restricted"),
+        ("teamshifts", "0015_custom_email_templates"),
     ]
 
     operations = [


### PR DESCRIPTION
Renames `0015_shiftassignment_role.py` → `0016_shiftassignment_role.py`

## Summary by Sourcery

Bug Fixes:
- Correct the shift assignment role migration dependency to reference the custom email templates migration and renumber it to avoid migration conflicts.