### PR TITLE
feat: public volunteer-facing shift schedule using pretalx-schedule widget

### DIFF
--- a/teamshifts/migrations/0017_cfm_shift_schedule_published.py
+++ b/teamshifts/migrations/0017_cfm_shift_schedule_published.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("teamshifts", "0016_shiftassignment_role"),
     ]

--- a/teamshifts/migrations/0017_cfm_shift_schedule_published.py
+++ b/teamshifts/migrations/0017_cfm_shift_schedule_published.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("teamshifts", "0016_shiftassignment_role"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="shift_schedule_published",
+            field=models.BooleanField(
+                default=False,
+                help_text="When enabled, accepted team members can view the shift schedule. Changes are live after the first publish.",
+                verbose_name="Shift schedule published",
+            ),
+        ),
+    ]

--- a/teamshifts/models.py
+++ b/teamshifts/models.py
@@ -93,6 +93,12 @@ class CallForTeamMembers(models.Model):
 
     field_order = models.JSONField(default=list, verbose_name=_("Field order"))
 
+    shift_schedule_published = models.BooleanField(
+        default=False,
+        verbose_name=_("Shift schedule published"),
+        help_text=_("When enabled, accepted team members can view the shift schedule. Changes are live after the first publish."),
+    )
+
     objects = ScopedManager(event="event")
 
     class Meta:

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -11,7 +11,7 @@ from eventyay.common.signals import periodic_task
 from eventyay.control.signals import event_dashboard_components, event_dashboard_widgets
 from eventyay.presale.signals import header_nav_tabs
 
-from .models import CallForTeamMembers
+from .models import ApplicationStatus, CallForTeamMembers, TeamMemberApplication
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,34 @@ def teamshifts_header_nav_tab(sender, request=None, **kwargs):
         apply_url,
         "active" if is_active else "",
         tab_title,
+    )
+
+
+@receiver(header_nav_tabs, dispatch_uid="teamshifts_public_schedule_nav_tab")
+def teamshifts_public_schedule_nav_tab(sender, request=None, **kwargs):
+    """Show the Shift Schedule tab only to accepted team members."""
+    if request is None or not request.user.is_authenticated:
+        return ""
+    from django_scopes import scope as _scope
+
+    with _scope(event=sender):
+        is_accepted = TeamMemberApplication.objects.filter(
+            event=sender,
+            user=request.user,
+            status=ApplicationStatus.ACCEPTED,
+        ).exists()
+    if not is_accepted:
+        return ""
+    schedule_url = reverse(
+        "plugins:teamshifts:public_shift_schedule",
+        kwargs={"organizer": sender.organizer.slug, "event": sender.slug},
+    )
+    is_active = request is not None and "/teamshifts/shifts/" in getattr(request, "path_info", "")
+    return format_html(
+        '<a href="{}" class="header-tab {}"><i class="fa fa-calendar-check-o"></i> {}</a>',
+        schedule_url,
+        "active" if is_active else "",
+        _("Shift Schedule"),
     )
 
 

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -85,7 +85,6 @@ def teamshifts_header_nav_tab(sender, request=None, **kwargs):
 
 @receiver(header_nav_tabs, dispatch_uid="teamshifts_public_schedule_nav_tab")
 def teamshifts_public_schedule_nav_tab(sender, request=None, **kwargs):
-    """Show the Shift Schedule tab only to accepted team members."""
     if request is None or not request.user.is_authenticated:
         return ""
     from django_scopes import scope as _scope

--- a/teamshifts/static/teamshifts/teamshifts.css
+++ b/teamshifts/static/teamshifts/teamshifts.css
@@ -140,3 +140,11 @@ label .optional {
 
 
 
+
+.ts-panel-table {
+    margin-bottom: 0;
+}
+
+.ts-detail-label {
+    width: 30%;
+}

--- a/teamshifts/static/teamshifts/teamshifts.css
+++ b/teamshifts/static/teamshifts/teamshifts.css
@@ -137,3 +137,17 @@ label .optional {
 #roles-table.js-formset-enabled .delete-checkbox {
     display: none;
 }
+
+
+
+.ts-inline-form {
+    display: inline;
+}
+
+.ts-schedule-header-actions {
+    margin-top: -5px;
+}
+
+.ts-schedule-header-actions .ts-inline-form + .btn {
+    margin-left: 6px;
+}

--- a/teamshifts/templates/teamshifts/schedule_grid.html
+++ b/teamshifts/templates/teamshifts/schedule_grid.html
@@ -18,9 +18,23 @@
 {% block content %}
     <h1>
         {% trans "Shift Schedule" %}
-        <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary pull-right">
-            <i class="fa fa-plus"></i> {% trans "Create Shift" %}
-        </a>
+        <span class="ts-schedule-header-actions pull-right">
+            <form method="post" action="{% url 'plugins:teamshifts:schedule_toggle_publish' organizer=request.event.organizer.slug event=request.event.slug %}" class="ts-inline-form">
+                {% csrf_token %}
+                {% if shift_schedule_published %}
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-eye-slash"></i> {% trans "Unpublish" %}
+                    </button>
+                {% else %}
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-globe"></i> {% trans "Publish" %}
+                    </button>
+                {% endif %}
+            </form>
+            <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary">
+                <i class="fa fa-plus"></i> {% trans "Create Shift" %}
+            </a>
+        </span>
     </h1>
 
     <div id="app" data-gettext="{{ gettext_language }}" data-mode="shifts" data-csrf-token="{{ csrf_token }}"></div>

--- a/teamshifts/templates/teamshifts/shift_detail.html
+++ b/teamshifts/templates/teamshifts/shift_detail.html
@@ -1,0 +1,98 @@
+{% extends "pretixpresale/event/base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block custom_header %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'teamshifts/teamshifts.css' %}">
+{% endblock %}
+
+{% block pagetitle %}{{ shift.name|default:"Shift" }} :: {{ event.name }}{% endblock %}
+
+{% block content %}
+  <h2>{{ shift.name|default:"Shift" }}</h2>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">{% trans "Shift details" %}</h3>
+    </div>
+    <table class="table table-condensed ts-panel-table">
+      <tbody>
+        <tr>
+          <th class="ts-detail-label">{% trans "Location" %}</th>
+          <td>{{ shift.location.name|default:"—" }}</td>
+        </tr>
+        <tr>
+          <th class="ts-detail-label">{% trans "Start" %}</th>
+          <td>{{ shift.start_time|date:"SHORT_DATETIME_FORMAT" }}</td>
+        </tr>
+        <tr>
+          <th class="ts-detail-label">{% trans "End" %}</th>
+          <td>{{ shift.end_time|date:"SHORT_DATETIME_FORMAT" }}</td>
+        </tr>
+        {% if shift.description %}
+        <tr>
+          <th class="ts-detail-label">{% trans "Description" %}</th>
+          <td>{{ shift.description }}</td>
+        </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+
+  {% if my_assignment %}
+  <div class="alert alert-success">
+    <span class="fa fa-check-circle"></span>
+    {% trans "You are signed up for this shift." %}
+  </div>
+  {% endif %}
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">{% trans "Roles" %}</h3>
+    </div>
+    {% if role_rows %}
+    <table class="table table-hover ts-panel-table">
+      <thead>
+        <tr>
+          <th>{% trans "Role" %}</th>
+          <th>{% trans "Assigned" %}</th>
+          <th>{% trans "Status" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in role_rows %}
+        <tr>
+          <td>
+            <strong>{{ row.role.name }}</strong>
+            {% if row.is_restricted %}
+              <span class="label label-default">{% trans "Restricted" %}</span>
+            {% endif %}
+          </td>
+          <td>{{ row.assigned_count }}/{{ row.capacity }}</td>
+          <td>
+            {% if row.assigned_count >= row.capacity %}
+              <span class="label label-success">{% trans "Full" %}</span>
+            {% elif row.assigned_count > 0 %}
+              <span class="label label-warning">{% trans "Partial" %}</span>
+            {% else %}
+              <span class="label label-danger">{% trans "Empty" %}</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="panel-body">
+      <p class="text-muted">{% trans "No roles configured for this shift." %}</p>
+    </div>
+    {% endif %}
+  </div>
+
+  <p>
+    <a href="{% url 'plugins:teamshifts:public_shift_schedule' organizer=request.organizer.slug event=request.event.slug %}" class="btn btn-default">
+      <span class="fa fa-arrow-left"></span> {% trans "Back to schedule" %}
+    </a>
+  </p>
+{% endblock %}

--- a/teamshifts/templates/teamshifts/shift_schedule.html
+++ b/teamshifts/templates/teamshifts/shift_schedule.html
@@ -1,0 +1,33 @@
+{% extends "agenda/base.html" %}
+{% load i18n %}
+{% load static %}
+{% load vite %}
+
+{% block container_width %} main-schedule{% endblock %}
+{% block pagetitle %}{% trans "Shift Schedule" %} :: {{ event.name }}{% endblock %}
+
+{% block agenda_custom_header %}
+{% endblock %}
+
+{% block header_right %}
+  {% include "common/fragment_header_user.html" with current_event=request.event nav_context="agenda" %}
+{% endblock header_right %}
+
+{% block agenda_content %}
+<div id="fahrplan" class="grid">
+  <script id="pretalx-schedule-data" type="application/json">{{ schedule_data_json|safe }}</script>
+  {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
+  <pretalx-schedule
+    event-url="{{ request.event.urls.base }}"
+    locale="{{ request.LANGUAGE_CODE }}"
+    timezone="{{ event_tz }}"
+    style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"
+    disable-auto-scroll
+  ></pretalx-schedule>
+  <noscript class="d-block">
+    <div class="alert alert-info m-4">
+      {% trans "Please enable JavaScript to view the shift schedule." %}
+    </div>
+  </noscript>
+</div>
+{% endblock agenda_content %}

--- a/teamshifts/templates/teamshifts/shift_schedule.html
+++ b/teamshifts/templates/teamshifts/shift_schedule.html
@@ -14,6 +14,11 @@
 {% endblock header_right %}
 
 {% block agenda_content %}
+{% if not shift_schedule_published %}
+<div class="alert alert-info m-4">
+  {% trans "The shift schedule has not been published yet. Please check back later." %}
+</div>
+{% else %}
 <div id="fahrplan" class="grid">
   <script id="pretalx-schedule-data" type="application/json">{{ schedule_data_json|safe }}</script>
   {% vite_app_scripts 'schedule' 'src/main-wc.js' fallback='schedule/pretalx-schedule.js' %}
@@ -30,4 +35,5 @@
     </div>
   </noscript>
 </div>
+{% endif %}
 {% endblock agenda_content %}

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -14,6 +14,31 @@ event_patterns = [
         views.PublicApplyThanksView.as_view(),
         name="apply_thanks",
     ),
+    path(
+        "teamshifts/shifts/",
+        views.PublicShiftScheduleView.as_view(),
+        name="public_shift_schedule",
+    ),
+    path(
+        "teamshifts/shifts/api/",
+        views.PublicShiftScheduleAPIView.as_view(),
+        name="public_shift_schedule_api",
+    ),
+    path(
+        "teamshifts/shifts/<int:pk>/",
+        views.ShiftDetailView.as_view(),
+        name="public_shift_detail",
+    ),
+    path(
+        "teamshifts/shifts/<int:pk>/claim/",
+        views.ShiftClaimView.as_view(),
+        name="public_shift_claim",
+    ),
+    path(
+        "teamshifts/shifts/<int:pk>/withdraw/",
+        views.ShiftWithdrawView.as_view(),
+        name="public_shift_withdraw",
+    ),
 ]
 
 urlpatterns = [

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -253,6 +253,11 @@ urlpatterns = [
         name="schedule_grid",
     ),
     path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/schedule/toggle-publish/",
+        views.ShiftScheduleTogglePublishView.as_view(),
+        name="schedule_toggle_publish",
+    ),
+    path(
         "teamshifts/event/<orgslug:organizer>/<slug:event>/emails/<int:pk>/send/",
         views.EmailQueueSendNowView.as_view(),
         name="email_send_now",

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1871,3 +1871,397 @@ class ShiftScheduleGridEditorView(PluginActiveMixin, EventPermissionRequiredMixi
         path = language_information.get("path", language_information.get("code", "en"))
         ctx["gettext_language"] = path.replace("-", "_")
         return ctx
+# ─── Public volunteer-facing shift schedule views ──────────────────────────
+
+
+def _get_accepted_application(request, event):
+    """Return the accepted TeamMemberApplication for the current user, or None."""
+    with scope(event=event):
+        return (
+            TeamMemberApplication.objects.filter(
+                event=event, user=request.user, status=ApplicationStatus.ACCEPTED
+            ).first()
+        )
+
+
+class PublicShiftScheduleMixin:
+    """Auth + plugin-active + accepted-member gate shared by all public shift views."""
+
+    def dispatch(self, request, *args, **kwargs):
+        if "teamshifts" not in request.event.get_plugins():
+            raise Http404
+        if not request.user.is_authenticated:
+            login_url = reverse("eventyay_common:auth.login")
+            return redirect(f"{login_url}?next={request.get_full_path()}")
+        self.event = request.event
+        self.organizer = request.organizer
+        self.member_application = _get_accepted_application(request, self.event)
+        if self.member_application is None:
+            messages.error(
+                request,
+                _("You need to be an accepted team member to view the shift schedule."),
+            )
+            return redirect(
+                reverse(
+                    "plugins:teamshifts:apply",
+                    kwargs={"organizer": self.organizer.slug, "event": self.event.slug},
+                )
+            )
+        return super().dispatch(request, *args, **kwargs)
+
+
+class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
+    def get(self, request, *args, **kwargs):
+        event = self.event
+        user = request.user
+
+        with scope(event=event):
+            my_shift_ids = set(
+                ShiftAssignment.objects.filter(
+                    shift__event=event, team_member=user
+                ).values_list("shift_id", flat=True)
+            )
+
+            data = {
+                "version": None,
+                "event_start": event.date_from.isoformat() if event.date_from else "",
+                "event_end": event.date_to.isoformat() if event.date_to else "",
+                "timezone": event.timezone,
+                "locales": ["en"],
+                "rooms": [],
+                "tracks": [],
+                "speakers": [],
+                "talks": [],
+                "warnings": {},
+                "roles": [],
+            }
+
+            for role in event.team_roles.all():
+                data["roles"].append({"id": role.id, "name": {"en": role.name}})
+
+            for loc in event.shift_locations.all():
+                data["rooms"].append({
+                    "id": loc.id,
+                    "name": {"en": loc.name},
+                    "description": {"en": loc.description or ""},
+                })
+
+            shifts = event.shifts.all().prefetch_related(
+                "role_assignments", "role_assignments__role", "assignments"
+            )
+            for shift in shifts:
+                roles_data = []
+                for sra in shift.role_assignments.all():
+                    assignments = []
+                    for a in shift.assignments.filter(
+                        team_member__isnull=False, role_id=sra.role_id
+                    ):
+                        assignments.append({
+                            "id": a.team_member_id,
+                            "name": a.team_member.get_full_name() or a.team_member.email,
+                        })
+                    roles_data.append({
+                        "id": sra.role_id,
+                        "name": {"en": sra.role.name},
+                        "capacity": sra.capacity,
+                        "assigned": assignments,
+                        "is_restricted": sra.role.is_restricted,
+                    })
+
+                duration = (
+                    int((shift.end_time - shift.start_time).total_seconds() / 60)
+                    if shift.end_time and shift.start_time
+                    else 0
+                )
+                data["talks"].append({
+                    "id": shift.id,
+                    "code": str(shift.id),
+                    "title": {"en": shift.name or "Shift"},
+                    "abstract": "",
+                    "description": shift.description,
+                    "room": shift.location_id,
+                    "start": shift.start_time.isoformat() if shift.start_time else "",
+                    "end": shift.end_time.isoformat() if shift.end_time else "",
+                    "duration": duration,
+                    "roles": roles_data,
+                    "state": "confirmed",
+                    "is_claimed_by_me": shift.id in my_shift_ids,
+                })
+
+        return JsonResponse(data)
+
+
+class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
+    template_name = "teamshifts/shift_schedule.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        import json as _json
+
+        event = self.event
+
+        with scope(event=event):
+            locations = list(event.shift_locations.all())
+            shifts = list(
+                event.shifts.all().prefetch_related(
+                    "role_assignments", "role_assignments__role", "assignments"
+                )
+            )
+
+        rooms = []
+        for loc in locations:
+            rooms.append({
+                "id": loc.id,
+                "name": loc.name,
+                "description": loc.description or "",
+            })
+
+        talks = []
+        for shift in shifts:
+            duration = (
+                int((shift.end_time - shift.start_time).total_seconds() / 60)
+                if shift.end_time and shift.start_time
+                else 0
+            )
+            roles_data = []
+            for sra in shift.role_assignments.all():
+                assigned_members = list(
+                    shift.assignments.filter(role_id=sra.role_id).select_related("team_member")
+                )
+                assigned_names = [
+                    a.team_member.get_full_name() or a.team_member.email
+                    for a in assigned_members if a.team_member
+                ]
+                roles_data.append({
+                    "id": sra.role_id,
+                    "name": sra.role.name,
+                    "capacity": sra.capacity,
+                    "assigned_count": len(assigned_members),
+                    "assigned_names": assigned_names,
+                    "is_restricted": sra.role.is_restricted,
+                })
+            abstract = shift.description or ""
+
+            talks.append({
+                "code": f"shift-{shift.id}",
+                "id": shift.id,
+                "title": shift.name or "Shift",
+                "abstract": abstract,
+                "description": shift.description or "",
+                "speakers": [],
+                "roles": roles_data,
+                "track": None,
+                "start": shift.start_time.isoformat() if shift.start_time else None,
+                "end": shift.end_time.isoformat() if shift.end_time else None,
+                "room": shift.location_id,
+                "duration": duration,
+                "state": "confirmed",
+                "do_not_record": False,
+            })
+
+        schedule_data = {
+            "talks": talks,
+            "rooms": rooms,
+            "tracks": [],
+            "speakers": [],
+            "version": None,
+            "timezone": str(event.timezone),
+            "event_start": event.date_from.isoformat() if event.date_from else "",
+            "event_end": event.date_to.isoformat() if event.date_to else "",
+            "content_locales": list(event.settings.locales or ["en"]),
+            "feature_flags": {},
+        }
+
+        json_str = _json.dumps(schedule_data, default=str)
+        json_escaped = json_str.translate({ord(">"): "\\u003E", ord("<"): "\\u003C", ord("&"): "\\u0026"})
+
+        ctx.update({
+            "event": event,
+            "event_tz": str(event.timezone),
+            "schedule_data_json": json_escaped,
+        })
+        return ctx
+
+
+class ShiftClaimView(PublicShiftScheduleMixin, View):
+    """POST-only: claim a shift slot with capacity enforcement."""
+
+    def post(self, request, *args, **kwargs):
+        event = self.event
+        shift_pk = kwargs["pk"]
+
+        with scope(event=event):
+            shift = get_object_or_404(Shift, pk=shift_pk, event=event)
+            sra = shift.role_assignments.select_related("role").first()
+
+            if sra is None:
+                messages.error(request, _("This shift has no roles configured."))
+                return redirect(
+                    reverse(
+                        "plugins:teamshifts:public_shift_schedule",
+                        kwargs={"organizer": self.organizer.slug, "event": event.slug},
+                    )
+                )
+
+            if sra.role.is_restricted:
+                messages.error(
+                    request,
+                    _("This shift requires organizer assignment — you cannot sign up directly."),
+                )
+                return redirect(
+                    reverse(
+                        "plugins:teamshifts:public_shift_schedule",
+                        kwargs={"organizer": self.organizer.slug, "event": event.slug},
+                    )
+                )
+
+            # Capacity-safe assignment inside a transaction with row-lock
+            with transaction.atomic():
+                # Lock the ShiftRoleAssignment row to prevent concurrent over-booking
+                sra_locked = ShiftRoleAssignment.objects.select_for_update().get(pk=sra.pk)
+                current_count = shift.assignments.count()
+                if current_count >= sra_locked.capacity:
+                    messages.error(request, _("Sorry, this shift is now full."))
+                    return redirect(
+                        reverse(
+                            "plugins:teamshifts:public_shift_schedule",
+                            kwargs={"organizer": self.organizer.slug, "event": event.slug},
+                        )
+                    )
+                assignment_obj, created = ShiftAssignment.objects.get_or_create(
+                    shift=shift,
+                    team_member=request.user,
+                    defaults={"assigned_by": None},
+                )
+
+            if created:
+                messages.success(request, _("You have been signed up for the shift."))
+            else:
+                messages.info(request, _("You were already signed up for this shift."))
+
+        return redirect(
+            reverse(
+                "plugins:teamshifts:public_shift_schedule",
+                kwargs={"organizer": self.organizer.slug, "event": event.slug},
+            )
+        )
+
+
+class ShiftDetailView(PublicShiftScheduleMixin, TemplateView):
+    """Per-shift detail page; shows withdraw button if user is assigned."""
+
+    template_name = "teamshifts/shift_detail.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.event
+
+        with scope(event=event):
+            shift = get_object_or_404(Shift, pk=self.kwargs["pk"], event=event)
+            role_rows = []
+            for sra in shift.role_assignments.select_related("role").all():
+                role_rows.append(
+                    {
+                        "role": sra.role,
+                        "capacity": sra.capacity,
+                        "assigned_count": shift.assignments.count(),
+                        "is_restricted": sra.role.is_restricted,
+                    }
+                )
+
+            my_assignment = ShiftAssignment.objects.filter(
+                shift=shift, team_member=self.request.user
+            ).first()
+
+        ctx.update(
+            {
+                "event": event,
+                "shift": shift,
+                "role_rows": role_rows,
+                "my_assignment": my_assignment,
+            }
+        )
+        return ctx
+
+
+class ShiftWithdrawView(PublicShiftScheduleMixin, View):
+    """POST-only: drop a claimed shift and notify organizers."""
+
+    def post(self, request, *args, **kwargs):
+        event = self.event
+        shift_pk = kwargs["pk"]
+
+        with scope(event=event):
+            shift = get_object_or_404(Shift, pk=shift_pk, event=event)
+            assignment = ShiftAssignment.objects.filter(
+                shift=shift, team_member=request.user
+            ).first()
+
+            if assignment is None:
+                messages.error(request, _("You are not signed up for this shift."))
+                return redirect(
+                    reverse(
+                        "plugins:teamshifts:public_shift_detail",
+                        kwargs={"organizer": self.organizer.slug, "event": event.slug, "pk": shift_pk},
+                    )
+                )
+
+            assignment.delete()
+
+        messages.success(request, _("You have been withdrawn from the shift."))
+
+        # Notify organizers asynchronously on commit
+        transaction.on_commit(
+            lambda: _notify_organizers_shift_dropped(event, request.user, shift)
+        )
+
+        return redirect(
+            reverse(
+                "plugins:teamshifts:public_shift_schedule",
+                kwargs={"organizer": self.organizer.slug, "event": event.slug},
+            )
+        )
+
+
+def _notify_organizers_shift_dropped(event, volunteer, shift):
+    """Queue a notification email to organizer staff when a volunteer drops a shift."""
+    from eventyay.base.models import User
+
+    try:
+        cfm = event.call_for_team_members
+    except CallForTeamMembers.DoesNotExist:
+        return
+
+    try:
+        template = cfm.get_mail_template(EmailTemplateRoles.SHIFT_DROPPED)
+    except Exception:
+        return
+
+    # Target: team members with can_change_event_settings for this event
+    with scopes_disabled():
+        organizer_users = list(
+            User.objects.filter(
+                teams__organizer=event.organizer,
+                teams__can_change_event_settings=True,
+                teams__all_events=True,
+            ).distinct()
+        )
+        if not organizer_users:
+            organizer_users = list(
+                User.objects.filter(
+                    teams__organizer=event.organizer,
+                    teams__limit_events=event,
+                    teams__can_change_event_settings=True,
+                ).distinct()
+            )
+
+    if not organizer_users:
+        return
+
+    queue_email(
+        event=event,
+        subject=template.subject,
+        message=template.body,
+        recipients=organizer_users,
+        status_filter="",
+    )

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -2016,6 +2016,8 @@ def _wants_json(request):
 
 
 class PublicShiftScheduleMixin:
+    redirect_unpublished_to_schedule = True
+
     def dispatch(self, request, *args, **kwargs):
         if "teamshifts" not in request.event.get_plugins():
             raise Http404
@@ -2041,17 +2043,18 @@ class PublicShiftScheduleMixin:
             )
         with scope(event=self.event):
             cfm = getattr(self.event, "call_for_team_members", None)
-            if not cfm or not cfm.shift_schedule_published:
-                messages.info(
-                    request,
-                    _("The shift schedule has not been published yet. Please check back later."),
+            self.shift_schedule_published = bool(cfm and cfm.shift_schedule_published)
+        if not self.shift_schedule_published and self.redirect_unpublished_to_schedule:
+            messages.info(
+                request,
+                _("The shift schedule has not been published yet. Please check back later."),
+            )
+            return redirect(
+                reverse(
+                    "plugins:teamshifts:public_shift_schedule",
+                    kwargs={"organizer": self.organizer.slug, "event": self.event.slug},
                 )
-                return redirect(
-                    reverse(
-                        "plugins:teamshifts:apply",
-                        kwargs={"organizer": self.organizer.slug, "event": self.event.slug},
-                    )
-                )
+            )
         return super().dispatch(request, *args, **kwargs)
 
 
@@ -2098,10 +2101,15 @@ class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
 @method_decorator(ensure_csrf_cookie, name="dispatch")
 class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
     template_name = "teamshifts/shift_schedule.html"
+    redirect_unpublished_to_schedule = False
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         event = self.event
+
+        if not self.shift_schedule_published:
+            ctx.update({"event": event, "shift_schedule_published": False})
+            return ctx
 
         with scope(event=event):
             locations = list(event.shift_locations.all())
@@ -2140,6 +2148,7 @@ class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
                 "event": event,
                 "event_tz": str(event.timezone),
                 "schedule_data_json": json_escaped,
+                "shift_schedule_published": True,
             }
         )
         return ctx

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from datetime import timedelta
 
@@ -64,6 +65,8 @@ from .permissions import TeamShiftsPermissionRequiredMixin, can_act_on_role, can
 ShiftRoleFormSet = inlineformset_factory(Shift, ShiftRoleAssignment, form=ShiftRoleAssignmentForm, formset=BaseShiftRoleFormSet, extra=1, can_delete=True)
 from .services.email import get_recipients, queue_email, queue_lifecycle_email
 from .tasks import send_queued_email
+
+logger = logging.getLogger(__name__)
 
 
 class PluginActiveMixin:
@@ -1904,27 +1907,35 @@ def _get_accepted_application(request, event):
         return TeamMemberApplication.objects.filter(event=event, user=request.user, status=ApplicationStatus.ACCEPTED).first()
 
 
+def _public_person_label(user, fallback):
+    if not user:
+        return fallback
+    name = (user.get_full_name() or "").strip()
+    return name or fallback
+
+
 def _shift_roles_payload(shift):
+    grouped = {}
+    for assignment in shift.assignments.all():
+        if not assignment.team_member_id or not assignment.role_id:
+            continue
+        assigned_by = assignment.assigned_by
+        grouped.setdefault(assignment.role_id, []).append(
+            {
+                "id": assignment.team_member_id,
+                "name": _public_person_label(assignment.team_member, str(_("Team member"))),
+                "self_assigned": assignment.assigned_by_id is None,
+                "assigned_by_name": _public_person_label(assigned_by, str(_("Organizer"))) if assigned_by else None,
+            }
+        )
     roles_data = []
     for sra in shift.role_assignments.all():
-        assignments = []
-        for assignment in shift.assignments.all():
-            if assignment.team_member_id and assignment.role_id == sra.role_id:
-                assigned_by = assignment.assigned_by
-                assignments.append(
-                    {
-                        "id": assignment.team_member_id,
-                        "name": assignment.team_member.get_full_name() or assignment.team_member.email,
-                        "self_assigned": assignment.assigned_by_id is None,
-                        "assigned_by_name": (assigned_by.get_full_name() or assigned_by.email) if assigned_by else None,
-                    }
-                )
         roles_data.append(
             {
                 "id": sra.role_id,
                 "name": {"en": sra.role.name},
                 "capacity": sra.capacity,
-                "assigned": assignments,
+                "assigned": grouped.get(sra.role_id, []),
                 "is_restricted": sra.role.is_restricted,
             }
         )
@@ -2018,8 +2029,8 @@ class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
                 "current_user_name": request.user.get_full_name() or request.user.email,
                 "event_start": event.date_from.isoformat() if event.date_from else "",
                 "event_end": event.date_to.isoformat() if event.date_to else "",
-                "timezone": event.timezone,
-                "locales": ["en"],
+                "timezone": str(event.timezone),
+                "locales": list(event.settings.locales or ["en"]),
                 "rooms": [],
                 "tracks": [],
                 "speakers": [],
@@ -2124,6 +2135,7 @@ class ShiftClaimView(PublicShiftScheduleMixin, View):
                 return fail(_("This role requires organizer assignment — you cannot sign up directly."))
 
             with transaction.atomic():
+                Shift.objects.select_for_update().get(pk=shift.pk, event=event)
                 sra_locked = ShiftRoleAssignment.objects.select_for_update().get(pk=sra.pk)
                 existing = ShiftAssignment.objects.select_for_update().filter(shift=shift, team_member=request.user).first()
                 if existing and existing.role_id and existing.role_id != sra.role_id:
@@ -2160,13 +2172,17 @@ class ShiftDetailView(PublicShiftScheduleMixin, TemplateView):
 
         with scope(event=event):
             shift = get_object_or_404(Shift, pk=self.kwargs["pk"], event=event)
+            assigned_counts_by_role = {
+                row["role_id"]: row["assigned_count"]
+                for row in ShiftAssignment.objects.filter(shift=shift).values("role_id").annotate(assigned_count=Count("id"))
+            }
             role_rows = []
             for sra in shift.role_assignments.select_related("role").all():
                 role_rows.append(
                     {
                         "role": sra.role,
                         "capacity": sra.capacity,
-                        "assigned_count": shift.assignments.count(),
+                        "assigned_count": assigned_counts_by_role.get(sra.role_id, 0),
                         "is_restricted": sra.role.is_restricted,
                     }
                 )
@@ -2235,6 +2251,7 @@ def _notify_organizers_shift_dropped(event, volunteer, shift):
     try:
         template = cfm.get_mail_template(EmailTemplateRoles.SHIFT_DROPPED)
     except Exception:
+        logger.exception("Failed to load shift-dropped email template for event %s", event.pk)
         return
 
     with scopes_disabled():

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1899,7 +1899,32 @@ class ShiftScheduleGridEditorView(PluginActiveMixin, TeamShiftsPermissionRequire
         language_information = get_language_info(get_language())
         path = language_information.get("path", language_information.get("code", "en"))
         ctx["gettext_language"] = path.replace("-", "_")
+
+        with scope(event=self.request.event):
+            cfm = getattr(self.request.event, "call_for_team_members", None)
+            ctx["shift_schedule_published"] = cfm.shift_schedule_published if cfm else False
         return ctx
+
+
+class ShiftScheduleTogglePublishView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, View):
+    permission = "can_teamshifts_create_shifts"
+
+    def post(self, request, *args, **kwargs):
+        event = request.event
+        with scope(event=event):
+            cfm, _created = CallForTeamMembers.objects.get_or_create(event=event)
+            cfm.shift_schedule_published = not cfm.shift_schedule_published
+            cfm.save(update_fields=["shift_schedule_published"])
+            if cfm.shift_schedule_published:
+                messages.success(request, _("Shift schedule has been published. Team members can now view it."))
+            else:
+                messages.success(request, _("Shift schedule has been unpublished. Team members can no longer view it."))
+        return redirect(
+            reverse(
+                "plugins:teamshifts:schedule_grid",
+                kwargs={"organizer": request.organizer.slug, "event": event.slug},
+            )
+        )
 
 
 def _get_accepted_application(request, event):
@@ -2014,6 +2039,19 @@ class PublicShiftScheduleMixin:
                     kwargs={"organizer": self.organizer.slug, "event": self.event.slug},
                 )
             )
+        with scope(event=self.event):
+            cfm = getattr(self.event, "call_for_team_members", None)
+            if not cfm or not cfm.shift_schedule_published:
+                messages.info(
+                    request,
+                    _("The shift schedule has not been published yet. Please check back later."),
+                )
+                return redirect(
+                    reverse(
+                        "plugins:teamshifts:apply",
+                        kwargs={"organizer": self.organizer.slug, "event": self.event.slug},
+                    )
+                )
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1896,12 +1896,90 @@ def _get_accepted_application(request, event):
         return TeamMemberApplication.objects.filter(event=event, user=request.user, status=ApplicationStatus.ACCEPTED).first()
 
 
+def _shift_roles_payload(shift):
+    roles_data = []
+    for sra in shift.role_assignments.all():
+        assignments = []
+        for assignment in shift.assignments.all():
+            if assignment.team_member_id and assignment.role_id == sra.role_id:
+                assigned_by = assignment.assigned_by
+                assignments.append(
+                    {
+                        "id": assignment.team_member_id,
+                        "name": assignment.team_member.get_full_name() or assignment.team_member.email,
+                        "self_assigned": assignment.assigned_by_id is None,
+                        "assigned_by_name": (assigned_by.get_full_name() or assigned_by.email) if assigned_by else None,
+                    }
+                )
+        roles_data.append(
+            {
+                "id": sra.role_id,
+                "name": {"en": sra.role.name},
+                "capacity": sra.capacity,
+                "assigned": assignments,
+                "is_restricted": sra.role.is_restricted,
+            }
+        )
+    return roles_data
+
+
+def _shift_talk_payload(shift):
+    duration = int((shift.end_time - shift.start_time).total_seconds() / 60) if shift.end_time and shift.start_time else 0
+    return {
+        "id": shift.id,
+        "code": str(shift.id),
+        "title": {"en": shift.name or "Shift"},
+        "abstract": "",
+        "description": shift.description or "",
+        "speakers": [],
+        "track": None,
+        "room": shift.location_id,
+        "start": shift.start_time.isoformat() if shift.start_time else "",
+        "end": shift.end_time.isoformat() if shift.end_time else "",
+        "duration": duration,
+        "roles": _shift_roles_payload(shift),
+        "state": "confirmed",
+        "do_not_record": False,
+    }
+
+
+def _public_shifts_queryset(event):
+    return event.shifts.all().prefetch_related(
+        "role_assignments__role",
+        "assignments__team_member",
+        "assignments__role",
+        "assignments__assigned_by",
+    )
+
+
+def _request_role_id(request):
+    role_id = request.POST.get("role_id")
+    if role_id is None and request.body:
+        try:
+            body = json.loads(request.body.decode())
+            role_id = body.get("role_id")
+        except (UnicodeDecodeError, json.JSONDecodeError, AttributeError):
+            role_id = None
+    try:
+        return int(role_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _wants_json(request):
+    accept = request.headers.get("Accept", "")
+    return request.headers.get("X-Requested-With") == "XMLHttpRequest" or "application/json" in accept
+
+
 class PublicShiftScheduleMixin:
     def dispatch(self, request, *args, **kwargs):
         if "teamshifts" not in request.event.get_plugins():
             raise Http404
         if not request.user.is_authenticated:
-            login_url = reverse("eventyay_common:auth.login")
+            login_url = reverse(
+                "cfp:event.login",
+                kwargs={"organizer": request.organizer.slug, "event": request.event.slug},
+            )
             return redirect(f"{login_url}?next={request.get_full_path()}")
         self.event = request.event
         self.organizer = request.organizer
@@ -1923,13 +2001,13 @@ class PublicShiftScheduleMixin:
 class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
     def get(self, request, *args, **kwargs):
         event = self.event
-        user = request.user
 
         with scope(event=event):
-            my_shift_ids = set(ShiftAssignment.objects.filter(shift__event=event, team_member=user).values_list("shift_id", flat=True))
-
             data = {
                 "version": None,
+                "mode": "shifts",
+                "current_user_id": request.user.pk,
+                "current_user_name": request.user.get_full_name() or request.user.email,
                 "event_start": event.date_from.isoformat() if event.date_from else "",
                 "event_end": event.date_to.isoformat() if event.date_to else "",
                 "timezone": event.timezone,
@@ -1943,7 +2021,7 @@ class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
             }
 
             for role in event.team_roles.all():
-                data["roles"].append({"id": role.id, "name": {"en": role.name}})
+                data["roles"].append({"id": role.id, "name": {"en": role.name}, "is_restricted": role.is_restricted})
 
             for loc in event.shift_locations.all():
                 data["rooms"].append(
@@ -1954,112 +2032,38 @@ class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
                     }
                 )
 
-            shifts = event.shifts.all().prefetch_related("role_assignments", "role_assignments__role", "assignments")
-            for shift in shifts:
-                roles_data = []
-                for sra in shift.role_assignments.all():
-                    assignments = []
-                    for a in shift.assignments.filter(team_member__isnull=False, role_id=sra.role_id):
-                        assignments.append(
-                            {
-                                "id": a.team_member_id,
-                                "name": a.team_member.get_full_name() or a.team_member.email,
-                            }
-                        )
-                    roles_data.append(
-                        {
-                            "id": sra.role_id,
-                            "name": {"en": sra.role.name},
-                            "capacity": sra.capacity,
-                            "assigned": assignments,
-                            "is_restricted": sra.role.is_restricted,
-                        }
-                    )
-
-                duration = int((shift.end_time - shift.start_time).total_seconds() / 60) if shift.end_time and shift.start_time else 0
-                data["talks"].append(
-                    {
-                        "id": shift.id,
-                        "code": str(shift.id),
-                        "title": {"en": shift.name or "Shift"},
-                        "abstract": "",
-                        "description": shift.description,
-                        "room": shift.location_id,
-                        "start": shift.start_time.isoformat() if shift.start_time else "",
-                        "end": shift.end_time.isoformat() if shift.end_time else "",
-                        "duration": duration,
-                        "roles": roles_data,
-                        "state": "confirmed",
-                        "is_claimed_by_me": shift.id in my_shift_ids,
-                    }
-                )
+            for shift in _public_shifts_queryset(event):
+                data["talks"].append(_shift_talk_payload(shift))
 
         return JsonResponse(data)
 
 
+@method_decorator(ensure_csrf_cookie, name="dispatch")
 class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
     template_name = "teamshifts/shift_schedule.html"
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        import json as _json
-
         event = self.event
 
         with scope(event=event):
             locations = list(event.shift_locations.all())
-            shifts = list(event.shifts.all().prefetch_related("role_assignments", "role_assignments__role", "assignments"))
+            shifts = list(_public_shifts_queryset(event))
 
-        rooms = []
-        for loc in locations:
-            rooms.append(
-                {
-                    "id": loc.id,
-                    "name": loc.name,
-                    "description": loc.description or "",
-                }
-            )
-
-        talks = []
-        for shift in shifts:
-            duration = int((shift.end_time - shift.start_time).total_seconds() / 60) if shift.end_time and shift.start_time else 0
-            roles_data = []
-            for sra in shift.role_assignments.all():
-                assigned_members = list(shift.assignments.filter(role_id=sra.role_id).select_related("team_member"))
-                assigned_names = [a.team_member.get_full_name() or a.team_member.email for a in assigned_members if a.team_member]
-                roles_data.append(
-                    {
-                        "id": sra.role_id,
-                        "name": sra.role.name,
-                        "capacity": sra.capacity,
-                        "assigned_count": len(assigned_members),
-                        "assigned_names": assigned_names,
-                        "is_restricted": sra.role.is_restricted,
-                    }
-                )
-            abstract = shift.description or ""
-
-            talks.append(
-                {
-                    "code": f"shift-{shift.id}",
-                    "id": shift.id,
-                    "title": shift.name or "Shift",
-                    "abstract": abstract,
-                    "description": shift.description or "",
-                    "speakers": [],
-                    "roles": roles_data,
-                    "track": None,
-                    "start": shift.start_time.isoformat() if shift.start_time else None,
-                    "end": shift.end_time.isoformat() if shift.end_time else None,
-                    "room": shift.location_id,
-                    "duration": duration,
-                    "state": "confirmed",
-                    "do_not_record": False,
-                }
-            )
+        rooms = [
+            {
+                "id": loc.id,
+                "name": {"en": loc.name},
+                "description": {"en": loc.description or ""},
+            }
+            for loc in locations
+        ]
 
         schedule_data = {
-            "talks": talks,
+            "mode": "shifts",
+            "current_user_id": self.request.user.pk,
+            "current_user_name": self.request.user.get_full_name() or self.request.user.email,
+            "talks": [_shift_talk_payload(shift) for shift in shifts],
             "rooms": rooms,
             "tracks": [],
             "speakers": [],
@@ -2071,7 +2075,7 @@ class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
             "feature_flags": {},
         }
 
-        json_str = _json.dumps(schedule_data, default=str)
+        json_str = json.dumps(schedule_data, default=str)
         json_escaped = json_str.translate({ord(">"): "\\u003E", ord("<"): "\\u003C", ord("&"): "\\u0026"})
 
         ctx.update(
@@ -2088,61 +2092,55 @@ class ShiftClaimView(PublicShiftScheduleMixin, View):
     def post(self, request, *args, **kwargs):
         event = self.event
         shift_pk = kwargs["pk"]
+        role_id = _request_role_id(request)
+        schedule_url = reverse(
+            "plugins:teamshifts:public_shift_schedule",
+            kwargs={"organizer": self.organizer.slug, "event": event.slug},
+        )
+
+        def fail(message, status=400):
+            if _wants_json(request):
+                return JsonResponse({"status": "error", "error": str(message)}, status=status)
+            messages.error(request, message)
+            return redirect(schedule_url)
+
+        if role_id is None:
+            return fail(_("Select a role to sign up for."))
 
         with scope(event=event):
             shift = get_object_or_404(Shift, pk=shift_pk, event=event)
-            sra = shift.role_assignments.select_related("role").first()
-
+            sra = shift.role_assignments.select_related("role").filter(role_id=role_id).first()
             if sra is None:
-                messages.error(request, _("This shift has no roles configured."))
-                return redirect(
-                    reverse(
-                        "plugins:teamshifts:public_shift_schedule",
-                        kwargs={"organizer": self.organizer.slug, "event": event.slug},
-                    )
-                )
-
+                return fail(_("This role is not configured for the shift."))
             if sra.role.is_restricted:
-                messages.error(
-                    request,
-                    _("This shift requires organizer assignment — you cannot sign up directly."),
-                )
-                return redirect(
-                    reverse(
-                        "plugins:teamshifts:public_shift_schedule",
-                        kwargs={"organizer": self.organizer.slug, "event": event.slug},
-                    )
-                )
+                return fail(_("This role requires organizer assignment — you cannot sign up directly."))
 
             with transaction.atomic():
-                # Lock the ShiftRoleAssignment row to prevent concurrent over-booking
                 sra_locked = ShiftRoleAssignment.objects.select_for_update().get(pk=sra.pk)
-                current_count = shift.assignments.count()
+                existing = ShiftAssignment.objects.select_for_update().filter(shift=shift, team_member=request.user).first()
+                if existing and existing.role_id and existing.role_id != sra.role_id:
+                    return fail(_("You are already signed up for another role on this shift."))
+                current_count = ShiftAssignment.objects.filter(shift=shift, role_id=sra.role_id).exclude(team_member=request.user).count()
                 if current_count >= sra_locked.capacity:
-                    messages.error(request, _("Sorry, this shift is now full."))
-                    return redirect(
-                        reverse(
-                            "plugins:teamshifts:public_shift_schedule",
-                            kwargs={"organizer": self.organizer.slug, "event": event.slug},
-                        )
-                    )
-                assignment_obj, created = ShiftAssignment.objects.get_or_create(
+                    return fail(_("Sorry, this role is now full."))
+                _assignment, created = ShiftAssignment.objects.update_or_create(
                     shift=shift,
                     team_member=request.user,
-                    defaults={"assigned_by": None},
+                    defaults={"role_id": sra.role_id, "assigned_by": None},
                 )
+            shift = Shift.objects.prefetch_related(
+                "role_assignments__role",
+                "assignments__team_member",
+                "assignments__role",
+            ).get(pk=shift.pk)
 
-            if created:
-                messages.success(request, _("You have been signed up for the shift."))
-            else:
-                messages.info(request, _("You were already signed up for this shift."))
-
-        return redirect(
-            reverse(
-                "plugins:teamshifts:public_shift_schedule",
-                kwargs={"organizer": self.organizer.slug, "event": event.slug},
-            )
-        )
+        if _wants_json(request):
+            return JsonResponse({"status": "ok", "roles": _shift_roles_payload(shift)})
+        if created:
+            messages.success(request, _("You have been signed up for the shift."))
+        else:
+            messages.info(request, _("You were already signed up for this shift."))
+        return redirect(schedule_url)
 
 
 class ShiftDetailView(PublicShiftScheduleMixin, TemplateView):
@@ -2182,32 +2180,40 @@ class ShiftWithdrawView(PublicShiftScheduleMixin, View):
     def post(self, request, *args, **kwargs):
         event = self.event
         shift_pk = kwargs["pk"]
+        role_id = _request_role_id(request)
+        schedule_url = reverse(
+            "plugins:teamshifts:public_shift_schedule",
+            kwargs={"organizer": self.organizer.slug, "event": event.slug},
+        )
+
+        def fail(message, status=400):
+            if _wants_json(request):
+                return JsonResponse({"status": "error", "error": str(message)}, status=status)
+            messages.error(request, message)
+            return redirect(schedule_url)
 
         with scope(event=event):
             shift = get_object_or_404(Shift, pk=shift_pk, event=event)
-            assignment = ShiftAssignment.objects.filter(shift=shift, team_member=request.user).first()
+            assignment_qs = ShiftAssignment.objects.filter(shift=shift, team_member=request.user)
+            if role_id is not None:
+                assignment_qs = assignment_qs.filter(role_id=role_id)
+            assignment = assignment_qs.first()
 
             if assignment is None:
-                messages.error(request, _("You are not signed up for this shift."))
-                return redirect(
-                    reverse(
-                        "plugins:teamshifts:public_shift_detail",
-                        kwargs={"organizer": self.organizer.slug, "event": event.slug, "pk": shift_pk},
-                    )
-                )
+                return fail(_("You are not signed up for this shift."))
 
             assignment.delete()
-
-        messages.success(request, _("You have been withdrawn from the shift."))
+            shift = Shift.objects.prefetch_related(
+                "role_assignments__role",
+                "assignments__team_member",
+                "assignments__role",
+            ).get(pk=shift.pk)
 
         transaction.on_commit(lambda: _notify_organizers_shift_dropped(event, request.user, shift))
-
-        return redirect(
-            reverse(
-                "plugins:teamshifts:public_shift_schedule",
-                kwargs={"organizer": self.organizer.slug, "event": event.slug},
-            )
-        )
+        if _wants_json(request):
+            return JsonResponse({"status": "ok", "roles": _shift_roles_payload(shift)})
+        messages.success(request, _("You have been withdrawn from the shift."))
+        return redirect(schedule_url)
 
 
 def _notify_organizers_shift_dropped(event, volunteer, shift):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1890,6 +1890,16 @@ class ShiftScheduleAssignmentsAPIView(PluginActiveMixin, TeamShiftsPermissionReq
                     if current_count >= role_assignment.capacity:
                         return HttpResponseBadRequest("Role capacity has been reached for this shift.")
 
+            if shift.start_time and shift.end_time:
+                conflicting = ShiftAssignment.objects.filter(
+                    team_member=user,
+                    shift__event=event,
+                    shift__start_time__lt=shift.end_time,
+                    shift__end_time__gt=shift.start_time,
+                ).exclude(shift=shift).select_related("shift").first()
+                if conflicting:
+                    return HttpResponseBadRequest("Member is already assigned to another shift during this time.")
+
             ShiftAssignment.objects.update_or_create(
                 shift=shift,
                 team_member=user,
@@ -2227,6 +2237,15 @@ class ShiftClaimView(PublicShiftScheduleMixin, View):
                 current_count = ShiftAssignment.objects.filter(shift=shift, role_id=sra.role_id).exclude(team_member=request.user).count()
                 if current_count >= sra_locked.capacity:
                     return fail(_("Sorry, this role is now full."))
+                if shift.start_time and shift.end_time:
+                    conflicting = ShiftAssignment.objects.filter(
+                        team_member=request.user,
+                        shift__event=event,
+                        shift__start_time__lt=shift.end_time,
+                        shift__end_time__gt=shift.start_time,
+                    ).exclude(shift=shift).select_related("shift").first()
+                    if conflicting:
+                        return fail(_("You are already assigned to another shift during this time."))
                 _assignment, created = ShiftAssignment.objects.update_or_create(
                     shift=shift,
                     team_member=request.user,

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1891,18 +1891,12 @@ class ShiftScheduleGridEditorView(PluginActiveMixin, TeamShiftsPermissionRequire
         return ctx
 
 
-# ─── Public volunteer-facing shift schedule views ──────────────────────────
-
-
 def _get_accepted_application(request, event):
-    """Return the accepted TeamMemberApplication for the current user, or None."""
     with scope(event=event):
         return TeamMemberApplication.objects.filter(event=event, user=request.user, status=ApplicationStatus.ACCEPTED).first()
 
 
 class PublicShiftScheduleMixin:
-    """Auth + plugin-active + accepted-member gate shared by all public shift views."""
-
     def dispatch(self, request, *args, **kwargs):
         if "teamshifts" not in request.event.get_plugins():
             raise Http404
@@ -2091,8 +2085,6 @@ class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
 
 
 class ShiftClaimView(PublicShiftScheduleMixin, View):
-    """POST-only: claim a shift slot with capacity enforcement."""
-
     def post(self, request, *args, **kwargs):
         event = self.event
         shift_pk = kwargs["pk"]
@@ -2122,7 +2114,6 @@ class ShiftClaimView(PublicShiftScheduleMixin, View):
                     )
                 )
 
-            # Capacity-safe assignment inside a transaction with row-lock
             with transaction.atomic():
                 # Lock the ShiftRoleAssignment row to prevent concurrent over-booking
                 sra_locked = ShiftRoleAssignment.objects.select_for_update().get(pk=sra.pk)
@@ -2155,8 +2146,6 @@ class ShiftClaimView(PublicShiftScheduleMixin, View):
 
 
 class ShiftDetailView(PublicShiftScheduleMixin, TemplateView):
-    """Per-shift detail page; shows withdraw button if user is assigned."""
-
     template_name = "teamshifts/shift_detail.html"
 
     def get_context_data(self, **kwargs):
@@ -2190,8 +2179,6 @@ class ShiftDetailView(PublicShiftScheduleMixin, TemplateView):
 
 
 class ShiftWithdrawView(PublicShiftScheduleMixin, View):
-    """POST-only: drop a claimed shift and notify organizers."""
-
     def post(self, request, *args, **kwargs):
         event = self.event
         shift_pk = kwargs["pk"]
@@ -2213,7 +2200,6 @@ class ShiftWithdrawView(PublicShiftScheduleMixin, View):
 
         messages.success(request, _("You have been withdrawn from the shift."))
 
-        # Notify organizers asynchronously on commit
         transaction.on_commit(lambda: _notify_organizers_shift_dropped(event, request.user, shift))
 
         return redirect(
@@ -2225,7 +2211,6 @@ class ShiftWithdrawView(PublicShiftScheduleMixin, View):
 
 
 def _notify_organizers_shift_dropped(event, volunteer, shift):
-    """Queue a notification email to organizer staff when a volunteer drops a shift."""
     from eventyay.base.models import User
 
     try:
@@ -2238,7 +2223,6 @@ def _notify_organizers_shift_dropped(event, volunteer, shift):
     except Exception:
         return
 
-    # Target: team members with can_change_event_settings for this event
     with scopes_disabled():
         organizer_users = list(
             User.objects.filter(

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1772,19 +1772,30 @@ class ShiftScheduleTalkAPIView(PluginActiveMixin, TeamShiftsPermissionRequiredMi
         with scope(event=event):
             shift = get_object_or_404(Shift, pk=kwargs["pk"], event=event)
 
-            try:
-                if "start" in data:
+            if data.get("start"):
+                try:
                     shift.start_time = dateutil.parser.parse(data["start"])
-                if "end" in data:
-                    shift.end_time = dateutil.parser.parse(data["end"])
-            except (TypeError, ValueError, OverflowError):
-                return HttpResponseBadRequest("Invalid date format for 'start'/'end'.")
+                    if data.get("end"):
+                        shift.end_time = dateutil.parser.parse(data["end"])
+                    elif shift.start_time and shift.end_time:
+                        duration = (shift.end_time - shift.start_time).total_seconds() / 60
+                        shift.end_time = shift.start_time + timedelta(minutes=duration)
+                    else:
+                        shift.end_time = shift.start_time + timedelta(minutes=data.get("duration", 60) or 60)
+                except (TypeError, ValueError, OverflowError):
+                    return HttpResponseBadRequest("Invalid date format for 'start'/'end'.")
 
-            if "room" in data:
-                room_id = data["room"]
-                if isinstance(room_id, dict):
-                    room_id = room_id.get("id")
-                shift.location = ShiftLocation.objects.filter(id=room_id, event=event).first() if room_id else None
+                if "room" in data:
+                    room_id = data["room"]
+                    if isinstance(room_id, dict):
+                        room_id = room_id.get("id")
+                    shift.location = ShiftLocation.objects.filter(id=room_id, event=event).first() if room_id else None
+
+                if shift.start_time and shift.end_time and shift.end_time <= shift.start_time:
+                    return HttpResponseBadRequest("'end' must be after 'start'.")
+            else:
+                shift.location = None
+
             if "title" in data:
                 title_val = data["title"]
                 if isinstance(title_val, dict):
@@ -1793,9 +1804,6 @@ class ShiftScheduleTalkAPIView(PluginActiveMixin, TeamShiftsPermissionRequiredMi
                     shift.name = title_val
             if "description" in data:
                 shift.description = data["description"]
-
-            if shift.start_time and shift.end_time and shift.end_time <= shift.start_time:
-                return HttpResponseBadRequest("'end' must be after 'start'.")
 
             shift.save()
 
@@ -2040,7 +2048,9 @@ def _shift_talk_payload(shift):
 
 
 def _public_shifts_queryset(event):
-    return event.shifts.all().prefetch_related(
+    return event.shifts.filter(
+        location__isnull=False,
+    ).prefetch_related(
         "role_assignments__role",
         "assignments__team_member",
         "assignments__role",

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1891,12 +1891,17 @@ class ShiftScheduleAssignmentsAPIView(PluginActiveMixin, TeamShiftsPermissionReq
                         return HttpResponseBadRequest("Role capacity has been reached for this shift.")
 
             if shift.start_time and shift.end_time:
-                conflicting = ShiftAssignment.objects.filter(
-                    team_member=user,
-                    shift__event=event,
-                    shift__start_time__lt=shift.end_time,
-                    shift__end_time__gt=shift.start_time,
-                ).exclude(shift=shift).select_related("shift").first()
+                conflicting = (
+                    ShiftAssignment.objects.filter(
+                        team_member=user,
+                        shift__event=event,
+                        shift__start_time__lt=shift.end_time,
+                        shift__end_time__gt=shift.start_time,
+                    )
+                    .exclude(shift=shift)
+                    .select_related("shift")
+                    .first()
+                )
                 if conflicting:
                     return HttpResponseBadRequest("Member is already assigned to another shift during this time.")
 
@@ -2238,12 +2243,17 @@ class ShiftClaimView(PublicShiftScheduleMixin, View):
                 if current_count >= sra_locked.capacity:
                     return fail(_("Sorry, this role is now full."))
                 if shift.start_time and shift.end_time:
-                    conflicting = ShiftAssignment.objects.filter(
-                        team_member=request.user,
-                        shift__event=event,
-                        shift__start_time__lt=shift.end_time,
-                        shift__end_time__gt=shift.start_time,
-                    ).exclude(shift=shift).select_related("shift").first()
+                    conflicting = (
+                        ShiftAssignment.objects.filter(
+                            team_member=request.user,
+                            shift__event=event,
+                            shift__start_time__lt=shift.end_time,
+                            shift__end_time__gt=shift.start_time,
+                        )
+                        .exclude(shift=shift)
+                        .select_related("shift")
+                        .first()
+                    )
                     if conflicting:
                         return fail(_("You are already assigned to another shift during this time."))
                 _assignment, created = ShiftAssignment.objects.update_or_create(


### PR DESCRIPTION
Closes #45 | Paired with PR https://github.com/fossasia/eventyay/pull/5006

Public, volunteer-facing shift schedule page for TeamShifts, built on the pretalx-schedule web component and paired with the eventyay adapter PR.

### What's here
- `shift_schedule.html` — public template mounting the schedule component
- New URLs and views serving public shift/role data for the schedule widget
- Signal wiring to surface the public schedule link where relevant


https://github.com/user-attachments/assets/e3fca232-3e85-4d2e-85ae-e6bf3899e267



## Summary by Sourcery

Provide accepted team members with an interactive public shift schedule for discovering and managing volunteer assignments.

New Features:
- Add an authenticated volunteer-facing shift schedule powered by the pretalx schedule widget.
- Allow accepted team members to view shift details, claim available shifts, and withdraw from their assignments.
- Expose schedule data through a widget-compatible API, including shifts, locations, roles, capacities, assignments, and personal claim status.

Enhancements:
- Add navigation to the public shift schedule for accepted team members.
- Notify organizers when a volunteer withdraws from a shift.

## Summary by Sourcery

Provide accepted team members with a public-facing shift schedule for discovering and managing volunteer assignments.

New Features:
- Add an interactive volunteer-facing shift schedule with widget-compatible event, location, role, capacity, and assignment data.
- Allow accepted team members to view shift details, claim eligible shifts, and withdraw from their assignments.

Enhancements:
- Restrict schedule access to authenticated accepted team members and provide contextual navigation to the schedule.
- Notify organizers when volunteers withdraw from shifts.

## Summary by Sourcery

Enable accepted team members to discover and manage volunteer shifts through a published public schedule.

New Features:
- Add a publishable volunteer shift schedule with an interactive schedule view, shift details, and widget-compatible schedule data.
- Allow accepted team members to claim eligible roles, withdraw from assignments, and receive conflict and capacity validation.

Bug Fixes:
- Prevent invalid shift updates and overlapping volunteer assignments.

Enhancements:
- Add contextual navigation to the schedule and notify organizers when volunteers withdraw from shifts.

Chores:
- Add event-level control for publishing or unpublishing the volunteer shift schedule.