### PR TITLE
feat: add secret link for private Call for Team Members

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -42,6 +42,7 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             "title",
             "active",
             "show_on_menu",
+            "cfm_private",
             "deadline",
             "description",
         )

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -65,6 +65,12 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             if not self.initial.get("deadline"):
                 self.initial["deadline"] = get_event_local_now(self._event)
 
+    def clean(self):
+        cleaned = super().clean()
+        if not cleaned.get("active") or cleaned.get("cfm_private"):
+            cleaned["show_on_menu"] = False
+        return cleaned
+
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
     class Meta:

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -65,12 +65,6 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             if not self.initial.get("deadline"):
                 self.initial["deadline"] = get_event_local_now(self._event)
 
-    def clean(self):
-        cleaned = super().clean()
-        if not cleaned.get("active") or cleaned.get("cfm_private"):
-            cleaned["show_on_menu"] = False
-        return cleaned
-
 
 class CallForTeamMembersApplicationSettingsForm(forms.ModelForm):
     class Meta:

--- a/teamshifts/migrations/0017_cfm_private_secret_link.py
+++ b/teamshifts/migrations/0017_cfm_private_secret_link.py
@@ -1,0 +1,34 @@
+import secrets
+
+from django.db import migrations, models
+
+
+def generate_cfm_secret():
+    return secrets.token_urlsafe(24)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("teamshifts", "0016_shiftassignment_role"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="cfm_private",
+            field=models.BooleanField(
+                default=False,
+                help_text="When enabled, the call is not linked from public pages. Only people with the secret link can access it.",
+                verbose_name="Private (secret link only)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="cfm_secret",
+            field=models.CharField(
+                default=generate_cfm_secret,
+                max_length=64,
+                verbose_name="Secret token",
+            ),
+        ),
+    ]

--- a/teamshifts/migrations/0017_cfm_private_secret_link.py
+++ b/teamshifts/migrations/0017_cfm_private_secret_link.py
@@ -3,6 +3,13 @@ from django.db import migrations, models
 import teamshifts.models
 
 
+def assign_unique_cfm_secrets(apps, schema_editor):
+    CallForTeamMembers = apps.get_model("teamshifts", "CallForTeamMembers")
+    for cfm in CallForTeamMembers.objects.all().iterator():
+        cfm.cfm_secret = teamshifts.models.generate_cfm_secret()
+        cfm.save(update_fields=["cfm_secret"])
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("teamshifts", "0016_shiftassignment_role"),
@@ -18,7 +25,18 @@ class Migration(migrations.Migration):
                 verbose_name="Private (secret link only)",
             ),
         ),
+        # Add nullable first so existing rows are not backfilled with one shared secret.
         migrations.AddField(
+            model_name="callforteammembers",
+            name="cfm_secret",
+            field=models.CharField(
+                max_length=64,
+                null=True,
+                verbose_name="Secret token",
+            ),
+        ),
+        migrations.RunPython(assign_unique_cfm_secrets, migrations.RunPython.noop),
+        migrations.AlterField(
             model_name="callforteammembers",
             name="cfm_secret",
             field=models.CharField(

--- a/teamshifts/migrations/0017_cfm_private_secret_link.py
+++ b/teamshifts/migrations/0017_cfm_private_secret_link.py
@@ -1,10 +1,6 @@
-import secrets
-
 from django.db import migrations, models
 
-
-def generate_cfm_secret():
-    return secrets.token_urlsafe(24)
+import teamshifts.models
 
 
 class Migration(migrations.Migration):
@@ -26,7 +22,7 @@ class Migration(migrations.Migration):
             model_name="callforteammembers",
             name="cfm_secret",
             field=models.CharField(
-                default=generate_cfm_secret,
+                default=teamshifts.models.generate_cfm_secret,
                 max_length=64,
                 verbose_name="Secret token",
             ),

--- a/teamshifts/models.py
+++ b/teamshifts/models.py
@@ -117,6 +117,10 @@ class CallForTeamMembers(models.Model):
         verbose_name_plural = _("Calls for Team Members")
 
     @property
+    def effective_show_on_menu(self) -> bool:
+        return self.active and not self.cfm_private and self.show_on_menu
+
+    @property
     def is_open(self):
         if not self.active:
             return False

--- a/teamshifts/models.py
+++ b/teamshifts/models.py
@@ -1,9 +1,16 @@
+import secrets
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_scopes import ScopedManager, scope
 from i18nfield.fields import I18nTextField
+
+
+def generate_cfm_secret():
+    return secrets.token_urlsafe(24)
+
 
 CFM_BUILTIN_FIELD_KEYS = ("full_name", "email", "phone", "availability")
 
@@ -57,6 +64,16 @@ class CallForTeamMembers(models.Model):
         verbose_name=_("Show in public navigation"),
         help_text=_("Show a link to the application form in the public event navigation. Only visible when Active is enabled."),
     )
+    cfm_private = models.BooleanField(
+        default=False,
+        verbose_name=_("Private (secret link only)"),
+        help_text=_("When enabled, the call is not linked from public pages. Only people with the secret link can access it."),
+    )
+    cfm_secret = models.CharField(
+        max_length=64,
+        default=generate_cfm_secret,
+        verbose_name=_("Secret token"),
+    )
     deadline = models.DateTimeField(null=True, blank=True, verbose_name=_("Deadline"))
     title = models.CharField(
         max_length=200,
@@ -106,6 +123,10 @@ class CallForTeamMembers(models.Model):
         if self.deadline and timezone.now() > self.deadline:
             return False
         return True
+
+    def regenerate_secret(self):
+        self.cfm_secret = generate_cfm_secret()
+        self.save(update_fields=["cfm_secret"])
 
     def get_ask_state(self, field_key: str) -> str:
         if field_key in CFM_LOCKED_FIELDS:

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -67,9 +67,7 @@ def teamshifts_header_nav_tab(sender, request=None, **kwargs):
         cfm = sender.call_for_team_members
     except CallForTeamMembers.DoesNotExist:
         return ""
-    if not cfm.active or not cfm.show_on_menu:
-        return ""
-    if cfm.cfm_private:
+    if not cfm.effective_show_on_menu:
         return ""
     apply_url = reverse(
         "plugins:teamshifts:apply",

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -69,6 +69,8 @@ def teamshifts_header_nav_tab(sender, request=None, **kwargs):
         return ""
     if not cfm.active or not cfm.show_on_menu:
         return ""
+    if cfm.cfm_private:
+        return ""
     apply_url = reverse(
         "plugins:teamshifts:apply",
         kwargs={"organizer": sender.organizer.slug, "event": sender.slug},

--- a/teamshifts/static/teamshifts/cfm_settings.js
+++ b/teamshifts/static/teamshifts/cfm_settings.js
@@ -73,6 +73,7 @@ function initDescriptionPreview() {
 
 document.addEventListener('DOMContentLoaded', function () {
   initDescriptionPreview();
+  initSecretLinkCopy();
   var activeEl = document.getElementById('id_active');
   var showOnMenuEl = document.getElementById('id_show_on_menu');
   if (!activeEl || !showOnMenuEl) return;
@@ -90,3 +91,33 @@ document.addEventListener('DOMContentLoaded', function () {
   activeEl.addEventListener('change', updateShowOnMenu);
   updateShowOnMenu();
 });
+
+function initSecretLinkCopy() {
+  var button = document.getElementById('cfm-copy-secret-link');
+  var input = document.getElementById('cfm-secret-link-input');
+  if (!button || !input) return;
+
+  button.addEventListener('click', function () {
+    input.select();
+    input.setSelectionRange(0, input.value.length);
+    var done = function () {
+      var icon = button.querySelector('i');
+      if (icon) icon.className = 'fa fa-check';
+      var textNode = button.childNodes[button.childNodes.length - 1];
+      if (textNode && textNode.nodeType === 3) textNode.textContent = ' Copied';
+      setTimeout(function () {
+        if (icon) icon.className = 'fa fa-copy';
+        if (textNode && textNode.nodeType === 3) textNode.textContent = ' Copy';
+      }, 1500);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(input.value).then(done, function () {
+        document.execCommand('copy');
+        done();
+      });
+    } else {
+      document.execCommand('copy');
+      done();
+    }
+  });
+}

--- a/teamshifts/static/teamshifts/cfm_settings.js
+++ b/teamshifts/static/teamshifts/cfm_settings.js
@@ -83,14 +83,22 @@ function initCallVisibilityToggles() {
   var privateEl = document.getElementById('id_cfm_private');
   if (!activeEl || !showOnMenuEl) return;
 
+  // Hidden input preserves the value when the checkbox is disabled.
+  var hidden = document.createElement('input');
+  hidden.type = 'hidden';
+  hidden.name = showOnMenuEl.name;
+  hidden.value = showOnMenuEl.checked ? 'on' : '';
+  showOnMenuEl.parentNode.insertBefore(hidden, showOnMenuEl);
+
+  showOnMenuEl.addEventListener('change', function () {
+    hidden.value = showOnMenuEl.checked ? 'on' : '';
+  });
+
   function updateShowOnMenu() {
     var row = showOnMenuEl.closest('.form-group') || showOnMenuEl.parentElement;
-    // Nav advertise only makes sense for an active, public call.
-    // Private mode is invite-only via secret link, so force menu off.
-    var canShowOnMenu = activeEl.checked && !(privateEl && privateEl.checked);
-    if (!canShowOnMenu) {
+    var hasEffect = activeEl.checked && !(privateEl && privateEl.checked);
+    if (!hasEffect) {
       showOnMenuEl.disabled = true;
-      showOnMenuEl.checked = false;
       if (row) row.style.opacity = '0.5';
     } else {
       showOnMenuEl.disabled = false;

--- a/teamshifts/static/teamshifts/cfm_settings.js
+++ b/teamshifts/static/teamshifts/cfm_settings.js
@@ -74,12 +74,21 @@ function initDescriptionPreview() {
 document.addEventListener('DOMContentLoaded', function () {
   initDescriptionPreview();
   initSecretLinkCopy();
+  initCallVisibilityToggles();
+});
+
+function initCallVisibilityToggles() {
   var activeEl = document.getElementById('id_active');
   var showOnMenuEl = document.getElementById('id_show_on_menu');
+  var privateEl = document.getElementById('id_cfm_private');
   if (!activeEl || !showOnMenuEl) return;
+
   function updateShowOnMenu() {
     var row = showOnMenuEl.closest('.form-group') || showOnMenuEl.parentElement;
-    if (!activeEl.checked) {
+    // Nav advertise only makes sense for an active, public call.
+    // Private mode is invite-only via secret link, so force menu off.
+    var canShowOnMenu = activeEl.checked && !(privateEl && privateEl.checked);
+    if (!canShowOnMenu) {
       showOnMenuEl.disabled = true;
       showOnMenuEl.checked = false;
       if (row) row.style.opacity = '0.5';
@@ -88,9 +97,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (row) row.style.opacity = '';
     }
   }
+
   activeEl.addEventListener('change', updateShowOnMenu);
+  if (privateEl) privateEl.addEventListener('change', updateShowOnMenu);
   updateShowOnMenu();
-});
+}
 
 function initSecretLinkCopy() {
   var button = document.getElementById('cfm-copy-secret-link');

--- a/teamshifts/static/teamshifts/cfm_settings.js
+++ b/teamshifts/static/teamshifts/cfm_settings.js
@@ -97,17 +97,27 @@ function initSecretLinkCopy() {
   var input = document.getElementById('cfm-secret-link-input');
   if (!button || !input) return;
 
+  var originalIcon = button.querySelector('i');
+  var originalIconClass = originalIcon ? originalIcon.className : 'fa fa-copy';
+  var originalLabel = button.textContent.trim();
+
+  function renderButton(iconClass, label) {
+    while (button.firstChild) {
+      button.removeChild(button.firstChild);
+    }
+    var icon = document.createElement('i');
+    icon.className = iconClass;
+    button.appendChild(icon);
+    button.appendChild(document.createTextNode(' ' + label));
+  }
+
   button.addEventListener('click', function () {
     input.select();
     input.setSelectionRange(0, input.value.length);
     var done = function () {
-      var icon = button.querySelector('i');
-      if (icon) icon.className = 'fa fa-check';
-      var textNode = button.childNodes[button.childNodes.length - 1];
-      if (textNode && textNode.nodeType === 3) textNode.textContent = ' Copied';
-      setTimeout(function () {
-        if (icon) icon.className = 'fa fa-copy';
-        if (textNode && textNode.nodeType === 3) textNode.textContent = ' Copy';
+      renderButton('fa fa-check', button.dataset.copiedLabel || gettext('Copied'));
+      window.setTimeout(function () {
+        renderButton(originalIconClass, originalLabel);
       }, 1500);
     };
     if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/teamshifts/static/teamshifts/teamshifts.css
+++ b/teamshifts/static/teamshifts/teamshifts.css
@@ -137,3 +137,24 @@ label .optional {
 #roles-table.js-formset-enabled .delete-checkbox {
     display: none;
 }
+
+
+.call-secret-panel {
+  margin-top: 20px;
+}
+
+.call-secret-input input[readonly] {
+  background-color: #fff;
+  font-family: monospace;
+}
+
+.call-secret-regenerate {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.call-secret-hint {
+  font-size: 12px;
+}

--- a/teamshifts/templates/teamshifts/cfm_settings.html
+++ b/teamshifts/templates/teamshifts/cfm_settings.html
@@ -63,12 +63,12 @@
             {% if cfm.active %}
                 {% if cfm.cfm_private %}
                     <a href="{% url 'plugins:teamshifts:apply_secret' organizer=request.organizer.slug event=request.event.slug secret=cfm.cfm_secret %}"
-                       class="btn btn-default" target="_blank" rel="noopener">
+                       class="btn btn-default btn-lg" target="_blank" rel="noopener">
                         <span class="fa fa-external-link"></span> {% trans "View call page" %}
                     </a>
                 {% else %}
                     <a href="{% url 'plugins:teamshifts:apply' organizer=request.organizer.slug event=request.event.slug %}"
-                       class="btn btn-default" target="_blank" rel="noopener">
+                       class="btn btn-default btn-lg" target="_blank" rel="noopener">
                         <span class="fa fa-external-link"></span> {% trans "View call page" %}
                     </a>
                 {% endif %}

--- a/teamshifts/templates/teamshifts/cfm_settings.html
+++ b/teamshifts/templates/teamshifts/cfm_settings.html
@@ -24,6 +24,7 @@
             {% bootstrap_field form.title layout="control" %}
             {% bootstrap_field form.active layout="control" %}
             {% bootstrap_field form.show_on_menu layout="control" %}
+            {% bootstrap_field form.cfm_private layout="control" %}
             {% bootstrap_field form.deadline layout="control" %}
             <div id="description_panel" class="form-group description-group">
                 <label class="col-md-3 control-label" for="{{ form.description.id_for_label }}">
@@ -60,10 +61,17 @@
         <div class="form-group submit-group">
             <button type="submit" class="btn btn-primary btn-save">{% trans "Save" %}</button>
             {% if cfm.active %}
-                <a href="{% url 'plugins:teamshifts:apply' organizer=request.organizer.slug event=request.event.slug %}"
-                   class="btn btn-default" target="_blank" rel="noopener">
-                    <span class="fa fa-external-link"></span> {% trans "View call page" %}
-                </a>
+                {% if cfm.cfm_private %}
+                    <a href="{% url 'plugins:teamshifts:apply_secret' organizer=request.organizer.slug event=request.event.slug secret=cfm.cfm_secret %}"
+                       class="btn btn-default" target="_blank" rel="noopener">
+                        <span class="fa fa-external-link"></span> {% trans "View call page" %}
+                    </a>
+                {% else %}
+                    <a href="{% url 'plugins:teamshifts:apply' organizer=request.organizer.slug event=request.event.slug %}"
+                       class="btn btn-default" target="_blank" rel="noopener">
+                        <span class="fa fa-external-link"></span> {% trans "View call page" %}
+                    </a>
+                {% endif %}
             {% endif %}
             <a href="{% url 'plugins:teamshifts:dashboard' organizer=request.organizer.slug event=request.event.slug %}"
                class="btn btn-default btn-lg">
@@ -71,4 +79,35 @@
             </a>
         </div>
     </form>
+
+    {% if cfm.active and cfm.cfm_private %}
+        <div class="panel panel-default call-secret-panel">
+            <div class="panel-heading">
+                <h3 class="panel-title"><i class="fa fa-lock"></i> {% trans "Secret call link" %}</h3>
+            </div>
+            <div class="panel-body">
+                <p class="text-muted">{% trans "This call is private: it is not linked anywhere public. Share the link below with the people you want to invite. Anyone who has it can open the call and apply." %}</p>
+                <div class="input-group call-secret-input">
+                    <input type="text" class="form-control" readonly
+                           value="{{ request.scheme }}://{{ request.get_host }}{% url 'plugins:teamshifts:apply_secret' organizer=request.organizer.slug event=request.event.slug secret=cfm.cfm_secret %}"
+                           id="cfm-secret-link-input">
+                    <span class="input-group-btn">
+                        <button type="button" class="btn btn-primary" id="cfm-copy-secret-link">
+                            <i class="fa fa-copy"></i> {% trans "Copy" %}
+                        </button>
+                    </span>
+                </div>
+                {% trans "Regenerate the secret link? The current link will stop working immediately." as regenerate_confirm_msg %}
+                <form action="" method="post" class="call-secret-regenerate">
+                    {% csrf_token %}
+                    <input type="hidden" name="action" value="regenerate_secret">
+                    <button type="submit" class="btn btn-default btn-sm"
+                            onclick="return confirm('{{ regenerate_confirm_msg|escapejs }}')">
+                        <i class="fa fa-refresh"></i> {% trans "Regenerate link" %}
+                    </button>
+                    <span class="text-muted call-secret-hint">{% trans "Regenerating immediately invalidates the current link." %}</span>
+                </form>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/teamshifts/templates/teamshifts/cfm_settings.html
+++ b/teamshifts/templates/teamshifts/cfm_settings.html
@@ -92,7 +92,8 @@
                            value="{{ request.scheme }}://{{ request.get_host }}{% url 'plugins:teamshifts:apply_secret' organizer=request.organizer.slug event=request.event.slug secret=cfm.cfm_secret %}"
                            id="cfm-secret-link-input">
                     <span class="input-group-btn">
-                        <button type="button" class="btn btn-primary" id="cfm-copy-secret-link">
+                        <button type="button" class="btn btn-primary" id="cfm-copy-secret-link"
+                                data-copied-label="{% trans 'Copied' %}" title="{% trans 'Copy to clipboard' %}">
                             <i class="fa fa-copy"></i> {% trans "Copy" %}
                         </button>
                     </span>

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -14,6 +14,11 @@ event_patterns = [
         views.PublicApplyThanksView.as_view(),
         name="apply_thanks",
     ),
+    path(
+        "teamshifts/apply/s/<str:secret>/",
+        views.PublicApplySecretView.as_view(),
+        name="apply_secret",
+    ),
 ]
 
 urlpatterns = [

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -120,6 +120,13 @@ class CFMSettingsView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, View
 
     def post(self, request, *args, **kwargs):
         cfm = self._get_cfm()
+
+        if request.POST.get("action") == "regenerate_secret":
+            with scope(event=request.event):
+                cfm.regenerate_secret()
+            messages.success(request, _("A new secret link has been generated. The old link no longer works."))
+            return redirect("plugins:teamshifts:cfm_settings", organizer=request.organizer.slug, event=request.event.slug)
+
         form = CallForTeamMembersSettingsForm(request.POST, instance=cfm, locales=request.event.settings.locales, event=request.event)
         if form.is_valid():
             with scope(event=request.event):
@@ -874,6 +881,10 @@ class ApplicationDetailView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin
         return ctx
 
 
+def _cfm_access_session_key(event):
+    return f"teamshifts_cfm_access_{event.pk}"
+
+
 class PublicApplyView(FormView):
     template_name = "teamshifts/apply.html"
 
@@ -890,6 +901,10 @@ class PublicApplyView(FormView):
                 self.cfm = self.event.call_for_team_members
             except CallForTeamMembers.DoesNotExist:
                 self.cfm = None
+        if self.cfm and self.cfm.cfm_private:
+            session_secret = request.session.get(_cfm_access_session_key(self.event))
+            if session_secret != self.cfm.cfm_secret:
+                raise Http404
         return super().dispatch(request, *args, **kwargs)
 
     def get_form(self, form_class=None):
@@ -958,6 +973,25 @@ class PublicApplyThanksView(TemplateView):
         ctx = super().get_context_data(**kwargs)
         ctx["event"] = self.event
         return ctx
+
+
+class PublicApplySecretView(PublicApplyView):
+    def dispatch(self, request, *args, **kwargs):
+        if "teamshifts" not in request.event.get_plugins():
+            raise Http404
+        event = request.event
+        with scope(event=event):
+            try:
+                cfm = event.call_for_team_members
+            except CallForTeamMembers.DoesNotExist:
+                raise Http404 from None
+        secret = kwargs.get("secret", "")
+        if not cfm.active or not cfm.cfm_private or not secret or secret != cfm.cfm_secret:
+            raise Http404
+        # Grant session access so subsequent requests to PublicApplyView also work
+        request.session[_cfm_access_session_key(event)] = secret
+        # Let PublicApplyView.dispatch handle the rest (it will pass the private check now)
+        return super().dispatch(request, *args, **kwargs)
 
 
 class EmailComposeView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, FormView):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -882,10 +882,6 @@ class ApplicationDetailView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin
         return ctx
 
 
-def _cfm_access_session_key(event):
-    return f"teamshifts_cfm_access_{event.pk}"
-
-
 class PublicApplyView(FormView):
     template_name = "teamshifts/apply.html"
 
@@ -906,9 +902,11 @@ class PublicApplyView(FormView):
             except CallForTeamMembers.DoesNotExist:
                 self.cfm = None
         if self.cfm and self.cfm.cfm_private:
-            session_secret = request.session.get(_cfm_access_session_key(self.event)) or ""
-            if not secrets.compare_digest(session_secret, self.cfm.cfm_secret or ""):
-                raise Http404
+            if not getattr(request, "_cfm_secret_verified", False):
+                with scope(event=self.event):
+                    has_application = TeamMemberApplication.objects.filter(event=self.event, user=request.user).exists()
+                if not has_application:
+                    raise Http404
         return super().dispatch(request, *args, **kwargs)
 
     def get_form(self, form_class=None):
@@ -995,9 +993,7 @@ class PublicApplySecretView(PublicApplyView):
         secret = kwargs.get("secret", "")
         if not cfm.active or not cfm.cfm_private or not secret or not secrets.compare_digest(secret, cfm.cfm_secret or ""):
             raise Http404
-        # Grant session access so subsequent requests to PublicApplyView also work
-        request.session[_cfm_access_session_key(event)] = secret
-        # Let PublicApplyView.dispatch handle the rest (it will pass the private check now)
+        request._cfm_secret_verified = True
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1,5 +1,6 @@
 import json
 import re
+import secrets
 from datetime import timedelta
 
 import dateutil.parser
@@ -892,7 +893,10 @@ class PublicApplyView(FormView):
         if "teamshifts" not in request.event.get_plugins():
             raise Http404
         if not request.user.is_authenticated:
-            login_url = reverse("eventyay_common:auth.login")
+            login_url = reverse(
+                "cfp:event.login",
+                kwargs={"organizer": request.organizer.slug, "event": request.event.slug},
+            )
             return redirect(f"{login_url}?next={request.get_full_path()}")
         self.event = request.event
         self.organizer = request.organizer
@@ -902,8 +906,8 @@ class PublicApplyView(FormView):
             except CallForTeamMembers.DoesNotExist:
                 self.cfm = None
         if self.cfm and self.cfm.cfm_private:
-            session_secret = request.session.get(_cfm_access_session_key(self.event))
-            if session_secret != self.cfm.cfm_secret:
+            session_secret = request.session.get(_cfm_access_session_key(self.event)) or ""
+            if not secrets.compare_digest(session_secret, self.cfm.cfm_secret or ""):
                 raise Http404
         return super().dispatch(request, *args, **kwargs)
 
@@ -964,7 +968,10 @@ class PublicApplyThanksView(TemplateView):
         if "teamshifts" not in request.event.get_plugins():
             raise Http404
         if not request.user.is_authenticated:
-            login_url = reverse("eventyay_common:auth.login")
+            login_url = reverse(
+                "cfp:event.login",
+                kwargs={"organizer": request.organizer.slug, "event": request.event.slug},
+            )
             return redirect(f"{login_url}?next={request.get_full_path()}")
         self.event = request.event
         return super().dispatch(request, *args, **kwargs)
@@ -986,7 +993,7 @@ class PublicApplySecretView(PublicApplyView):
             except CallForTeamMembers.DoesNotExist:
                 raise Http404 from None
         secret = kwargs.get("secret", "")
-        if not cfm.active or not cfm.cfm_private or not secret or secret != cfm.cfm_secret:
+        if not cfm.active or not cfm.cfm_private or not secret or not secrets.compare_digest(secret, cfm.cfm_secret or ""):
             raise Http404
         # Grant session access so subsequent requests to PublicApplyView also work
         request.session[_cfm_access_session_key(event)] = secret


### PR DESCRIPTION
Closes #93 

#### Summary
Adds a "private" mode for the Call for Team Members (CFM), similar to the existing pattern in the `eventyay-exhibition` plugin. Organizers can mark the call as private, which hides it from public navigation and instead exposes a secret, shareable URL. Anyone with the link can view and apply; the link can be regenerated at any time to invalidate the old one.

#### Changes
- `models.py`: added `cfm_private` (bool) and `cfm_secret` (token) fields to `CallForTeamMembers`, plus `generate_cfm_secret()` and `regenerate_secret()`
- `migrations/0017_cfm_private_secret_link.py`: adds the two new columns
- `forms.py`: exposes `cfm_private` on `CallForTeamMembersSettingsForm`
- `views.py`: `PublicApplyView` now enforces private access via a session check; new `PublicApplySecretView` validates the secret token and grants session access
- `urls.py`: new route `teamshifts/apply/s/<str:secret>/`
- `signals.py`: hides the "Call for Team Members" nav tab when the call is private
- `templates/teamshifts/cfm_settings.html`: renders the `cfm_private` checkbox and a secret-link panel (copy + regenerate) once the call is active and private
- `static/teamshifts/cfm_settings.js`: clipboard copy handler for the secret link
- `static/teamshifts/teamshifts.css`: styling for the secret-link panel

#### Risk and Rollback
Low risk — additive fields and an opt-in toggle, defaulting to `cfm_private=False` (no behavior change for existing events). Rollback is a straightforward revert; the migration only adds columns, no data migration involved.

## Summary by Sourcery

Enable organizers to restrict Call for Team Members pages to people who possess a valid secret link.

New Features:
- Add private Call for Team Members mode with shareable secret-link access and link regeneration.

Enhancements:
- Hide private calls from public event navigation while preserving access for users with a valid link.
- Expose private-call controls and secret-link copy functionality in the organizer settings.

Chores:
- Add database fields and migration for private-call state and secret tokens.

## Summary by Sourcery

Enable organizers to restrict Call for Team Members applications to invitees with a valid secret link.

New Features:
- Add private Call for Team Members pages that are accessible through shareable secret links.
- Allow organizers to copy and regenerate secret links, immediately invalidating previous links.

Enhancements:
- Hide private calls from public event navigation while retaining access for users with valid links or existing applications.
- Expose private-call visibility controls in the organizer settings.

Chores:
- Add database fields and migration for private-call settings and secret tokens.