### PR TITLE
feat: add event component nav to TeamShifts organizer pages

### DIFF
--- a/teamshifts/templates/teamshifts/application_detail.html
+++ b/teamshifts/templates/teamshifts/application_detail.html
@@ -9,15 +9,11 @@
 
 {% block title %}{% trans "Application Details" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Application Details" %}</h1>
-            </div>
-        </div>
-    </nav>
-    
+{% block teamshifts_header %}
+        <h1>{% trans "Application Details" %}</h1>
+{% endblock %}
+
+{% block teamshifts_content %}
     <div class="teamshifts-detail-header-container">
         {% if application.status == 'accepted' %}
             <a href="{% url 'plugins:teamshifts:members' organizer=request.organizer.slug event=request.event.slug %}" class="btn btn-default">

--- a/teamshifts/templates/teamshifts/applications.html
+++ b/teamshifts/templates/teamshifts/applications.html
@@ -9,16 +9,11 @@
 
 {% block title %}{% trans "Team Applications" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Applications" %}</h1>
-            </div>
+{% block teamshifts_header %}
+        <h1>{% trans "Applications" %}</h1>
+{% endblock %}
 
-        </div>
-    </nav>
-
+{% block teamshifts_content %}
     <div class="teamshifts-filter-bar">
         <form method="get" class="form-inline pull-left">
         <div class="form-group">

--- a/teamshifts/templates/teamshifts/base.html
+++ b/teamshifts/templates/teamshifts/base.html
@@ -160,3 +160,37 @@
         </ul>
     </li>
 {% endblock %}
+
+{% block content %}
+  <nav id="event-nav" class="header-nav">
+    <div class="navigation">
+      <div class="navigation-title">
+        {% block teamshifts_header %}
+          <h1>{% trans "TeamShifts" %}</h1>
+        {% endblock %}
+      </div>
+      <div class="navigation-button">
+        <a href="{% url 'eventyay_common:event.index' organizer=request.organizer.slug event=request.event.slug %}" class="header-nav btn btn-outline-success">
+          <i class="fa fa-home"></i> {% trans "Home" %}
+        </a>
+        {% if 'can_change_event_settings' in request.eventpermset %}
+          <a href="{% url 'control:event.index' organizer=request.organizer.slug event=request.event.slug %}" class="header-nav btn btn-outline-success">
+            <i class="fa fa-ticket"></i> {% trans "Tickets" %}
+          </a>
+          {% if is_talk_event_created %}
+            <a href="{% url 'orga:event.dashboard' organizer=request.organizer.slug event=request.event.slug %}" class="header-nav btn btn-outline-success">
+              <i class="fa fa-group"></i> {% trans "Talks" %}
+            </a>
+          {% endif %}
+          <a class="header-nav btn btn-outline-success"
+             href="{% url 'eventyay_common:event.create_access_to_video' organizer=request.organizer.slug event=request.event.slug %}"
+             title="{% trans 'Access videos related to this event' %}">
+            <i class="fa fa-video-camera"></i> {% trans "Videos" %}
+          </a>
+        {% endif %}
+      </div>
+    </div>
+  </nav>
+
+  {% block teamshifts_content %}{% endblock %}
+{% endblock %}

--- a/teamshifts/templates/teamshifts/cfm_application_form.html
+++ b/teamshifts/templates/teamshifts/cfm_application_form.html
@@ -9,15 +9,11 @@
     <script defer src="{% static 'orga/js/questionToggles.js' %}"></script>
 {% endblock %}
 {% block title %}{{ cfm.title }} :: {{ request.event.name }}{% endblock %}
-{% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Call for Team Members" %}</h1>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+        <h1>{% trans "Call for Team Members" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/teamshifts/templates/teamshifts/cfm_settings.html
+++ b/teamshifts/templates/teamshifts/cfm_settings.html
@@ -7,15 +7,11 @@
     <script defer src="{% static 'teamshifts/cfm_settings.js' %}"></script>
 {% endblock %}
 {% block title %}{{ cfm.title }} :: {{ request.event.name }}{% endblock %}
-{% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Call for Team Members" %}</h1>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+        <h1>{% trans "Call for Team Members" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/teamshifts/templates/teamshifts/custom_email_template_delete.html
+++ b/teamshifts/templates/teamshifts/custom_email_template_delete.html
@@ -4,20 +4,11 @@
 
 {% block title %}{% trans "Delete Template" %}{% endblock %}
 
-{% block content %}
-    <nav id='event-nav' class='header-nav'>
-        <div class='navigation'>
-            <div class='navigation-title'>
-                <h1>{% trans "Delete Template" %}</h1>
-            </div>
-            <div class='navigation-action'>
-                <a href='{% url "plugins:teamshifts:email_templates" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-default'>
-                    {% trans "Cancel" %}
-                </a>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+  <h1>{% trans "Delete Template" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         <div class="panel panel-danger">

--- a/teamshifts/templates/teamshifts/custom_email_template_form.html
+++ b/teamshifts/templates/teamshifts/custom_email_template_form.html
@@ -6,16 +6,12 @@
   {% if object %}{% trans "Edit template" %}{% else %}{% trans "New template" %}{% endif %} :: {{ request.event.name }}
 {% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>{% if object %}{% trans "Edit template" %}{% else %}{% trans "New template" %}{% endif %}</h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  <form method='post' class='form-horizontal'>
+{% block teamshifts_content %}
+    <form method='post' class='form-horizontal'>
     {% csrf_token %}
     {% bootstrap_form_errors form %}
     {% bootstrap_field form.name layout="control" %}

--- a/teamshifts/templates/teamshifts/dashboard.html
+++ b/teamshifts/templates/teamshifts/dashboard.html
@@ -3,19 +3,15 @@
 
 {% block title %}{% trans "TeamShifts" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h2>
           {{ request.event.name }}
           <small class='text-muted'>{{ request.event.get_date_range_display }}</small>
         </h2>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  <div class='dashboard'>
+{% block teamshifts_content %}
+    <div class='dashboard'>
     <div class='widget-container widget-small'>
       <a href='{% url "plugins:teamshifts:roles" organizer=request.organizer.slug event=request.event.slug %}' class='widget'>
         <div class='numwidget'>

--- a/teamshifts/templates/teamshifts/email_template_edit.html
+++ b/teamshifts/templates/teamshifts/email_template_edit.html
@@ -4,14 +4,11 @@
 
 {% block title %}{% trans "Edit email template" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <nav id='event-nav' class='header-nav'>
-        <div class='navigation'>
-            <div class='navigation-title'>
-                <h1>{{ role_label }}</h1>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+        <h1>{{ role_label }}</h1>
+{% endblock %}
+
+{% block teamshifts_content %}
     <p class='help-block'>
         {% blocktrans trimmed %}
         Available placeholders: <code>{full_name}</code>, <code>{event_name}</code>,

--- a/teamshifts/templates/teamshifts/email_templates.html
+++ b/teamshifts/templates/teamshifts/email_templates.html
@@ -10,21 +10,17 @@
   <script defer src='{% static "teamshifts/email_templates.js" %}'></script>
 {% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
-        <h1>{% trans "Email templates" %}</h1>
-      </div>
-      <div class='navigation-actions'>
-        <a href='{% url "plugins:teamshifts:custom_email_template_create" organizer=request.organizer.slug event=request.event.slug %}'
-           class='btn btn-primary'>
-          <i class='fa fa-plus'></i> {% trans "New template" %}
-        </a>
-      </div>
-    </div>
-  </nav>
+{% block teamshifts_header %}
+  <h1>{% trans "Email templates" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
+  <p class='text-right'>
+    <a href='{% url "plugins:teamshifts:custom_email_template_create" organizer=request.organizer.slug event=request.event.slug %}'
+       class='btn btn-primary'>
+      <i class='fa fa-plus'></i> {% trans "New template" %}
+    </a>
+  </p>
   <p class='text-muted'>
     {% blocktrans trimmed %}
       These templates are used for the confirmation email sent when an applicant

--- a/teamshifts/templates/teamshifts/emails/compose.html
+++ b/teamshifts/templates/teamshifts/emails/compose.html
@@ -10,16 +10,12 @@
 
 {% block title %}{% trans "Compose email" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>{% trans "Compose email" %}</h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  <p class='help-block'>
+{% block teamshifts_content %}
+    <p class='help-block'>
     {% blocktrans trimmed %}
       Write a message to your team members. You can filter recipients by role
       and application status. Send immediately or schedule it for later.

--- a/teamshifts/templates/teamshifts/emails/delete_confirmation.html
+++ b/teamshifts/templates/teamshifts/emails/delete_confirmation.html
@@ -3,16 +3,12 @@
 
 {% block title %}{% trans "Delete email" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>{% trans "Delete email" %}</h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  <h4>{% trans "Do you really want to delete this email?" %}</h4>
+{% block teamshifts_content %}
+    <h4>{% trans "Do you really want to delete this email?" %}</h4>
   <p><strong>{% trans "Subject" %}:</strong> {{ queue.subject }}</p>
 
   <form method='post' class='submit-group'>

--- a/teamshifts/templates/teamshifts/emails/outbox_form.html
+++ b/teamshifts/templates/teamshifts/emails/outbox_form.html
@@ -10,16 +10,12 @@
 
 {% block title %}{% trans "Edit email" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>{% trans "Edit email" %}</h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  {% if queue.sent_at %}
+{% block teamshifts_content %}
+    {% if queue.sent_at %}
     <div class='alert alert-info'>
       {% blocktrans with timestamp=queue.sent_at %}
         This email was sent on {{ timestamp }} and cannot be edited.

--- a/teamshifts/templates/teamshifts/emails/outbox_list.html
+++ b/teamshifts/templates/teamshifts/emails/outbox_list.html
@@ -3,10 +3,7 @@
 
 {% block title %}{% trans "Outbox" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>
           {% blocktrans count mail_count=mails|length trimmed %}
             {{ mail_count }} pending email
@@ -14,16 +11,15 @@
             {{ mail_count }} pending emails
           {% endblocktrans %}
         </h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  <div class='submit-group'>
+{% block teamshifts_content %}
+  <p class='text-right'>
     <a href='{% url "plugins:teamshifts:email_compose" organizer=request.organizer.slug event=request.event.slug %}'
        class='btn btn-primary'>
       <i class='fa fa-plus'></i> {% trans "New email" %}
     </a>
-  </div>
+  </p>
 
   <table class='table'>
     <thead>

--- a/teamshifts/templates/teamshifts/emails/sent_list.html
+++ b/teamshifts/templates/teamshifts/emails/sent_list.html
@@ -3,10 +3,7 @@
 
 {% block title %}{% trans "Sent emails" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>
           {% blocktrans count mail_count=mails|length trimmed %}
             {{ mail_count }} sent email
@@ -14,16 +11,15 @@
             {{ mail_count }} sent emails
           {% endblocktrans %}
         </h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  <div class='submit-group'>
+{% block teamshifts_content %}
+  <p class='text-right'>
     <a href='{% url "plugins:teamshifts:email_compose" organizer=request.organizer.slug event=request.event.slug %}'
        class='btn btn-primary'>
       <i class='fa fa-plus'></i> {% trans "New email" %}
     </a>
-  </div>
+  </p>
 
   <table class='table'>
     <thead>

--- a/teamshifts/templates/teamshifts/location_delete.html
+++ b/teamshifts/templates/teamshifts/location_delete.html
@@ -4,20 +4,11 @@
 
 {% block title %}{% trans "Delete Location" %}{% endblock %}
 
-{% block content %}
-    <nav id='event-nav' class='header-nav'>
-        <div class='navigation'>
-            <div class='navigation-title'>
-                <h1>{% trans "Delete Location" %}</h1>
-            </div>
-            <div class='navigation-action'>
-                <a href='{% url "plugins:teamshifts:locations" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-default'>
-                    {% trans "Cancel" %}
-                </a>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+  <h1>{% trans "Delete Location" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         <div class="panel panel-danger">

--- a/teamshifts/templates/teamshifts/location_edit.html
+++ b/teamshifts/templates/teamshifts/location_edit.html
@@ -6,23 +6,14 @@
   {% if location %}{% trans "Edit Location" %}{% else %}{% trans "Add Location" %}{% endif %}
 {% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
-        <h1>
-          {% if location %}{% trans "Edit Location" %}{% else %}{% trans "Add Location" %}{% endif %}
-        </h1>
-      </div>
-      <div class='navigation-action'>
-        <a href='{% url "plugins:teamshifts:locations" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-default'>
-          {% trans "Back" %}
-        </a>
-      </div>
-    </div>
-  </nav>
+{% block teamshifts_header %}
+  <h1>
+    {% if location %}{% trans "Edit Location" %}{% else %}{% trans "Add Location" %}{% endif %}
+  </h1>
+{% endblock %}
 
-  <div class='panel panel-default'>
+{% block teamshifts_content %}
+    <div class='panel panel-default'>
     <div class='panel-heading'>
       <h3 class='panel-title'>
         {% if location %}{% trans "Edit location details" %}{% else %}{% trans "Location details" %}{% endif %}

--- a/teamshifts/templates/teamshifts/locations.html
+++ b/teamshifts/templates/teamshifts/locations.html
@@ -4,51 +4,47 @@
 
 {% block title %}{% trans "Locations" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <nav id='event-nav' class='header-nav'>
-        <div class='navigation'>
-            <div class='navigation-title'>
-                <h1>{% trans "Locations" %}</h1>
-            </div>
-            <div class='navigation-action'>
-                <a href='{% url "plugins:teamshifts:location_create" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-primary'>
-                    <span class='fa fa-plus'></span> {% trans "Add location" %}
-                </a>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+  <h1>{% trans "Locations" %}</h1>
+{% endblock %}
 
-    {% if not locations %}
-        <div class='empty-collection'>
-            <p>{% blocktrans trimmed %}No locations have been defined for this event yet.{% endblocktrans %}</p>
-        </div>
-    {% else %}
-        <div class='table-responsive'>
-            <table class='table table-hover table-quotas'>
-                <thead>
-                    <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Description" %}</th>
-                        <th class='text-right'>{% trans "Actions" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for location in locations %}
-                        <tr>
-                            <td><strong>{{ location.name }}</strong></td>
-                            <td class='text-muted'>{{ location.description|default:"—" }}</td>
-                            <td class='text-right flip'>
-                                <a href='{% url "plugins:teamshifts:location_edit" organizer=request.organizer.slug event=request.event.slug pk=location.pk %}' class='btn btn-default btn-sm'>
-                                    <span class='fa fa-edit'></span> {% trans "Edit" %}
-                                </a>
-                                <a href='{% url "plugins:teamshifts:location_delete" organizer=request.organizer.slug event=request.event.slug pk=location.pk %}' class='btn btn-danger btn-sm'>
-                                    <span class='fa fa-trash'></span> {% trans "Delete" %}
-                                </a>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
+{% block teamshifts_content %}
+  <p class="text-right">
+    <a href='{% url "plugins:teamshifts:location_create" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-primary'>
+      <span class='fa fa-plus'></span> {% trans "Add location" %}
+    </a>
+  </p>
+  {% if not locations %}
+    <div class='empty-collection'>
+      <p>{% blocktrans trimmed %}No locations have been defined for this event yet.{% endblocktrans %}</p>
+    </div>
+  {% else %}
+    <div class='table-responsive'>
+      <table class='table table-hover table-quotas'>
+        <thead>
+          <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Description" %}</th>
+            <th class='text-right'>{% trans "Actions" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for location in locations %}
+            <tr>
+              <td><strong>{{ location.name }}</strong></td>
+              <td class='text-muted'>{{ location.description|default:"—" }}</td>
+              <td class='text-right flip'>
+                <a href='{% url "plugins:teamshifts:location_edit" organizer=request.organizer.slug event=request.event.slug pk=location.pk %}' class='btn btn-default btn-sm'>
+                  <span class='fa fa-edit'></span> {% trans "Edit" %}
+                </a>
+                <a href='{% url "plugins:teamshifts:location_delete" organizer=request.organizer.slug event=request.event.slug pk=location.pk %}' class='btn btn-danger btn-sm'>
+                  <span class='fa fa-trash'></span> {% trans "Delete" %}
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/teamshifts/templates/teamshifts/members.html
+++ b/teamshifts/templates/teamshifts/members.html
@@ -9,15 +9,11 @@
 {% endblock %}
 {% block title %}{% trans "Members" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <nav id="event-nav" class="header-nav">
-        <div class="navigation">
-            <div class="navigation-title">
-                <h1>{% trans "Members" %}</h1>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+        <h1>{% trans "Members" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form method="get" class="form-inline" style="margin-bottom: 1em;">
         <div class="form-group">
             <input type="text" name="q" value="{{ request.GET.q|default:'' }}" class="form-control" placeholder="{% trans 'Search by name or email' %}">

--- a/teamshifts/templates/teamshifts/question_edit.html
+++ b/teamshifts/templates/teamshifts/question_edit.html
@@ -7,15 +7,11 @@
     :: {{ request.event.name }}
 {% endblock %}
 
-{% block content %}
-    <nav id='event-nav' class='header-nav'>
-        <div class='navigation'>
-            <div class='navigation-title'>
-                <h1>{% if question %}{% trans "Edit question" %}{% else %}{% trans "New question" %}{% endif %}</h1>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+        <h1>{% if question %}{% trans "Edit question" %}{% else %}{% trans "New question" %}{% endif %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form action='' method='post' class='form-horizontal'>
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/teamshifts/templates/teamshifts/role_edit.html
+++ b/teamshifts/templates/teamshifts/role_edit.html
@@ -4,21 +4,12 @@
 
 {% block title %}{% trans "Edit Role" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
-        <h1>{% blocktrans trimmed with name=role.name %}Edit Role "{{ name }}"{% endblocktrans %}</h1>
-      </div>
-      <div class='navigation-action'>
-        <a href='{% url "plugins:teamshifts:roles" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-default'>
-          {% trans "Back" %}
-        </a>
-      </div>
-    </div>
-  </nav>
+{% block teamshifts_header %}
+  <h1>{% blocktrans trimmed with name=role.name %}Edit Role "{{ name }}"{% endblocktrans %}</h1>
+{% endblock %}
 
-  <div class='panel panel-default'>
+{% block teamshifts_content %}
+    <div class='panel panel-default'>
     <div class='panel-heading'>
       <h3 class='panel-title'>{% trans "Role details" %}</h3>
     </div>

--- a/teamshifts/templates/teamshifts/roles.html
+++ b/teamshifts/templates/teamshifts/roles.html
@@ -4,16 +4,12 @@
 
 {% block title %}{% trans "Team Roles" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-  <nav id='event-nav' class='header-nav'>
-    <div class='navigation'>
-      <div class='navigation-title'>
+{% block teamshifts_header %}
         <h1>{% trans "Team Roles" %}</h1>
-      </div>
-    </div>
-  </nav>
+{% endblock %}
 
-  {% if not roles %}
+{% block teamshifts_content %}
+    {% if not roles %}
     <div class='empty-collection'>
       <p>{% blocktrans trimmed %}No roles have been defined for this event yet.{% endblocktrans %}</p>
     </div>

--- a/teamshifts/templates/teamshifts/schedule_grid.html
+++ b/teamshifts/templates/teamshifts/schedule_grid.html
@@ -15,13 +15,15 @@
 
 {% block title %}{% trans "Shift Schedule" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <h1>
-        {% trans "Shift Schedule" %}
-        <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary pull-right">
-            <i class="fa fa-plus"></i> {% trans "Create Shift" %}
-        </a>
-    </h1>
+{% block teamshifts_header %}
+  <h1>{% trans "Shift Schedule" %}</h1>
+{% endblock %}
 
-    <div id="app" data-gettext="{{ gettext_language }}" data-mode="shifts" data-csrf-token="{{ csrf_token }}"></div>
+{% block teamshifts_content %}
+  <p class="text-right">
+    <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary">
+      <i class="fa fa-plus"></i> {% trans "Create Shift" %}
+    </a>
+  </p>
+  <div id="app" data-gettext="{{ gettext_language }}" data-mode="shifts" data-csrf-token="{{ csrf_token }}"></div>
 {% endblock %}

--- a/teamshifts/templates/teamshifts/shift_create.html
+++ b/teamshifts/templates/teamshifts/shift_create.html
@@ -8,9 +8,11 @@
   <script type='module' src='{% static "teamshifts/shift_create.js" %}'></script>
 {% endblock %}
 
-{% block content %}
+{% block teamshifts_header %}
   <h1>{% trans "Create Shift(s)" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
   {% if not has_locations %}
     <div class='alert alert-warning'>
       {% trans "No locations defined yet, add locations first." %}

--- a/teamshifts/templates/teamshifts/shift_delete.html
+++ b/teamshifts/templates/teamshifts/shift_delete.html
@@ -4,20 +4,11 @@
 
 {% block title %}{% trans "Delete Shift" %}{% endblock %}
 
-{% block content %}
-    <nav id='event-nav' class='header-nav'>
-        <div class='navigation'>
-            <div class='navigation-title'>
-                <h1>{% trans "Delete Shift" %}</h1>
-            </div>
-            <div class='navigation-action'>
-                <a href='{% url "plugins:teamshifts:shifts" organizer=request.organizer.slug event=request.event.slug %}' class='btn btn-default'>
-                    {% trans "Cancel" %}
-                </a>
-            </div>
-        </div>
-    </nav>
+{% block teamshifts_header %}
+  <h1>{% trans "Delete Shift" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         <div class="panel panel-danger">

--- a/teamshifts/templates/teamshifts/shift_edit.html
+++ b/teamshifts/templates/teamshifts/shift_edit.html
@@ -8,9 +8,11 @@
   <script type='module' src='{% static "teamshifts/shift_edit.js" %}'></script>
 {% endblock %}
 
-{% block content %}
+{% block teamshifts_header %}
   <h1>{% trans "Edit Shift" %}</h1>
+{% endblock %}
 
+{% block teamshifts_content %}
   {% if not has_locations %}
     <div class='alert alert-warning'>
       {% trans "No locations defined yet, add locations first." %}

--- a/teamshifts/templates/teamshifts/shifts.html
+++ b/teamshifts/templates/teamshifts/shifts.html
@@ -3,15 +3,17 @@
 
 {% block title %}{% trans "Shifts" %} :: {{ request.event.name }}{% endblock %}
 
-{% block content %}
-    <h1>
-        {% trans "Shifts" %}
-        <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary pull-right">
-            <i class="fa fa-plus"></i> {% trans "Create Shift" %}
-        </a>
-    </h1>
+{% block teamshifts_header %}
+  <h1>{% trans "Shifts" %}</h1>
+{% endblock %}
 
-    <div class="table-responsive">
+{% block teamshifts_content %}
+  <p class="text-right">
+    <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary">
+      <i class="fa fa-plus"></i> {% trans "Create Shift" %}
+    </a>
+  </p>
+  <div class="table-responsive">
         <table class="table table-hover table-striped">
             <thead>
             <tr>


### PR DESCRIPTION
Closes #106 

#### Summary
- Add a persistent Home / Tickets / Talks / Videos navigation bar to all TeamShifts organizer pages, matching the exhibition plugin pattern.
- Centralize the header in `teamshifts/base.html` with `teamshifts_header` and `teamshifts_content` blocks so child templates no longer duplicate `event-nav` markup.
- Move page action buttons (Add location, Create Shift, New template, New email) below the component nav and right-align them so they no longer sit flush against the navigation buttons.


https://github.com/user-attachments/assets/47e0b37d-0f44-4921-8a9a-b4bab4621fc9

## Summary by Sourcery

Standardize TeamShifts organizer page navigation and layout across all views.

New Features:
- Add persistent Home, Tickets, Talks, and Videos navigation to TeamShifts organizer pages, with links shown according to event permissions and configuration.

Enhancements:
- Centralize TeamShifts page headers and content through a shared template layout, removing duplicated navigation markup across organizer pages.
- Reposition page-level action buttons below the component navigation with right alignment for clearer separation.