### PR TITLE
fix: show arrived status on TeamShifts dashboard members table

### DIFF
--- a/teamshifts/templates/teamshifts/dashboard.html
+++ b/teamshifts/templates/teamshifts/dashboard.html
@@ -103,7 +103,7 @@
         <div class='panel-heading'>
           <h3 class='panel-title'>
             {% trans "Accepted Team Members" %}
-            <a href='{% url "plugins:teamshifts:applications" organizer=request.organizer.slug event=request.event.slug %}?status=accepted'
+            <a href='{% url "plugins:teamshifts:members" organizer=request.organizer.slug event=request.event.slug %}'
                class='pull-right flip'>
               <small>{% trans "View all" %}</small>
             </a>
@@ -115,7 +115,7 @@
               <thead>
                 <tr>
                   <th>{% trans "Member" %}</th>
-                  <th>{% trans "Attendance" %}</th>
+                  <th>{% trans "Arrived" %}</th>
                 </tr>
               </thead>
               <tbody>
@@ -123,12 +123,10 @@
                   <tr>
                     <td>{{ app.user.fullname|default:app.user.email }}</td>
                     <td>
-                      {% if app.attendance_confirmed is None %}
-                        <span class='label label-default'>{% trans "Not confirmed" %}</span>
-                      {% elif app.attendance_confirmed %}
-                        <span class='label label-success'>{% trans "Confirmed" %}</span>
+                      {% if app.arrived %}
+                        <span class='label label-success'>{% trans "Arrived" %}</span>
                       {% else %}
-                        <span class='label label-danger'>{% trans "Declined" %}</span>
+                        <span class='label label-default'>{% trans "Not arrived" %}</span>
                       {% endif %}
                     </td>
                   </tr>


### PR DESCRIPTION
Closes #111 

#### Summary
- Replace the unused Attendance column on the TeamShifts dashboard with Arrived / Not arrived from `application.arrived`.
- Align the dashboard with the Members page toggle so presence updates show on the dashboard.
- Point “View all” in the accepted members panel to the Members page.

<img width="2286" height="1023" alt="image" src="https://github.com/user-attachments/assets/8babf0c8-198c-48e8-81ff-2fccd940fefd" />

<img width="2286" height="1040" alt="image" src="https://github.com/user-attachments/assets/e7100bff-c507-44f1-a05a-71d55286c407" />

## Summary by Sourcery

Display current member arrival status on the TeamShifts dashboard and direct users to the Members page for the full member list.

Bug Fixes:
- Show each accepted member’s arrived or not-arrived status on the TeamShifts dashboard using the current presence state.

Enhancements:
- Replace the dashboard’s unused attendance status with an arrived status and link the accepted members panel to the Members page.