### PR TITLE
fix: cap repeating shift creation at 50 per action

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -519,9 +519,6 @@ class ShiftLocationForm(forms.ModelForm):
         return cleaned_data
 
 
-MAX_REPEATING_SHIFTS_PER_ACTION = 50
-
-
 class ShiftForm(forms.ModelForm):
     mode = forms.ChoiceField(
         choices=[("single", _("Single shift")), ("repeating", _("Repeating shifts"))],
@@ -594,11 +591,10 @@ class ShiftForm(forms.ModelForm):
                     self.add_error("shift_length_minutes", _("The shift length must divide evenly into the total duration between start and end time."))
                 else:
                     count = duration_seconds // (shift_length * 60)
-                    if count > MAX_REPEATING_SHIFTS_PER_ACTION:
+                    if count > 50:
                         self.add_error(
                             "shift_length_minutes",
-                            _("The maximum allowed is %(max)d per action. Please adjust the interval or date range.")
-                            % {"max": MAX_REPEATING_SHIFTS_PER_ACTION},
+                            _("The maximum allowed is 50 per action. Please adjust the interval or date range."),
                         )
         return cleaned_data
 

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -519,6 +519,9 @@ class ShiftLocationForm(forms.ModelForm):
         return cleaned_data
 
 
+MAX_REPEATING_SHIFTS_PER_ACTION = 50
+
+
 class ShiftForm(forms.ModelForm):
     mode = forms.ChoiceField(
         choices=[("single", _("Single shift")), ("repeating", _("Repeating shifts"))],
@@ -589,6 +592,14 @@ class ShiftForm(forms.ModelForm):
                 duration_seconds = int((end_time - start_time).total_seconds())
                 if duration_seconds % (shift_length * 60) != 0:
                     self.add_error("shift_length_minutes", _("The shift length must divide evenly into the total duration between start and end time."))
+                else:
+                    count = duration_seconds // (shift_length * 60)
+                    if count > MAX_REPEATING_SHIFTS_PER_ACTION:
+                        self.add_error(
+                            "shift_length_minutes",
+                            _("The maximum allowed is %(max)d per action. Please adjust the interval or date range.")
+                            % {"max": MAX_REPEATING_SHIFTS_PER_ACTION},
+                        )
         return cleaned_data
 
 

--- a/tests/test_shift_create.py
+++ b/tests/test_shift_create.py
@@ -127,6 +127,33 @@ def test_shift_create_repeating_rejects_more_than_cap(orga_client, event, locati
 
 
 @pytest.mark.django_db
+def test_shift_create_repeating_allows_exactly_cap(orga_client, event, location, team_role):
+    url = reverse("plugins:teamshifts:shift_create", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    start = now() + timedelta(days=1)
+    end = start + timedelta(hours=50)  # 50 one-hour shifts
+
+    data = {
+        "mode": "repeating",
+        "name": "At cap",
+        "location": location.pk,
+        "start_time": start.strftime("%Y-%m-%dT%H:%M"),
+        "end_time": end.strftime("%Y-%m-%dT%H:%M"),
+        "shift_length_minutes": "60",
+        "roles-TOTAL_FORMS": "1",
+        "roles-INITIAL_FORMS": "0",
+        "roles-MIN_NUM_FORMS": "0",
+        "roles-MAX_NUM_FORMS": "1000",
+        "roles-0-role": team_role.pk,
+        "roles-0-capacity": "1",
+    }
+
+    response = orga_client.post(url, data)
+    assert response.status_code == 302
+    with scope(event=event):
+        assert Shift.objects.count() == 50
+
+
+@pytest.mark.django_db
 def test_shift_create_repeating_invalid_remainder(orga_client, event, location, team_role):
     url = reverse("plugins:teamshifts:shift_create", kwargs={"organizer": event.organizer.slug, "event": event.slug})
     start = now() + timedelta(days=1)

--- a/tests/test_shift_create.py
+++ b/tests/test_shift_create.py
@@ -99,6 +99,34 @@ def test_shift_create_repeating_success(orga_client, event, location, team_role)
 
 
 @pytest.mark.django_db
+def test_shift_create_repeating_rejects_more_than_cap(orga_client, event, location, team_role):
+    url = reverse("plugins:teamshifts:shift_create", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    start = now() + timedelta(days=1)
+    end = start + timedelta(hours=51)  # 51 one-hour shifts
+
+    data = {
+        "mode": "repeating",
+        "name": "Too many",
+        "location": location.pk,
+        "start_time": start.strftime("%Y-%m-%dT%H:%M"),
+        "end_time": end.strftime("%Y-%m-%dT%H:%M"),
+        "shift_length_minutes": "60",
+        "roles-TOTAL_FORMS": "1",
+        "roles-INITIAL_FORMS": "0",
+        "roles-MIN_NUM_FORMS": "0",
+        "roles-MAX_NUM_FORMS": "1000",
+        "roles-0-role": team_role.pk,
+        "roles-0-capacity": "1",
+    }
+
+    response = orga_client.post(url, data)
+    assert response.status_code == 200
+    assert b"The maximum allowed is 50 per action" in response.content
+    with scope(event=event):
+        assert Shift.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_shift_create_repeating_invalid_remainder(orga_client, event, location, team_role):
     url = reverse("plugins:teamshifts:shift_create", kwargs={"organizer": event.organizer.slug, "event": event.slug})
     start = now() + timedelta(days=1)


### PR DESCRIPTION
Repeating shift mode had no upper bound. A mistyped interval created tens of thousands of shifts in one submit; the UI warned after the fact but still inserted the rows.

`ShiftForm.clean` now refuses a repeating range that would create more than 50 shifts and shows:

> The maximum allowed is 50 per action. Please adjust the interval or date range.

Fixes #118

## Testing

Adds `test_shift_create_repeating_rejects_more_than_cap` next to the existing repeating-success case. The 51-hour / 60-minute range stays on the form (HTTP 200) and inserts nothing.

## Summary by Sourcery

Limit repeating shift creation to 50 shifts per action and reject larger ranges with a validation error.

Bug Fixes:
- Prevent repeating shift submissions from creating more than 50 shifts in a single action.

Tests:
- Add coverage for rejecting ranges above the cap while allowing exactly 50 shifts.