### PR TITLE
feat: add bulk delete and pagination to shifts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ EVY_POSTGRES_HOST = "localhost"
 EVY_POSTGRES_PORT = "5432"
 EVY_POSTGRES_USER = "postgres"
 EVY_POSTGRES_PASSWORD = "postgres"
-EVY_POSTGRES_DB = "eventyay"
+EVY_POSTGRES_DB = "eventyay-db"
 
 [tool.ruff]
 line-length = 160

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,11 @@ testpaths = ["tests"]
 
 [tool.pytest_env]
 EVY_RUNNING_ENVIRONMENT = "testing"
-EVY_POSTGRES_HOST = "eventyay-next-db"
+EVY_POSTGRES_HOST = "localhost"
 EVY_POSTGRES_PORT = "5432"
-EVY_POSTGRES_USER = "eventyay_dev_user"
-EVY_POSTGRES_PASSWORD = "eventyay_dev_pass"
-EVY_POSTGRES_DB = "eventyay_dev"
+EVY_POSTGRES_USER = "postgres"
+EVY_POSTGRES_PASSWORD = "postgres"
+EVY_POSTGRES_DB = "eventyay"
 
 [tool.ruff]
 line-length = 160

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,11 @@ testpaths = ["tests"]
 
 [tool.pytest_env]
 EVY_RUNNING_ENVIRONMENT = "testing"
-EVY_POSTGRES_HOST = "localhost"
+EVY_POSTGRES_HOST = "eventyay-next-db"
 EVY_POSTGRES_PORT = "5432"
-EVY_POSTGRES_USER = "postgres"
-EVY_POSTGRES_PASSWORD = "postgres"
-EVY_POSTGRES_DB = "eventyay-db"
+EVY_POSTGRES_USER = "eventyay_dev_user"
+EVY_POSTGRES_PASSWORD = "eventyay_dev_pass"
+EVY_POSTGRES_DB = "eventyay_dev"
 
 [tool.ruff]
 line-length = 160

--- a/teamshifts/static/teamshifts/shifts.js
+++ b/teamshifts/static/teamshifts/shifts.js
@@ -1,0 +1,48 @@
+function gettext(msgid) {
+    return typeof window.gettext === "function" ? window.gettext(msgid) : msgid;
+}
+
+function setupSelectAll() {
+    const selectAll = document.getElementById("select-all");
+    if (!selectAll) {
+        return;
+    }
+
+    selectAll.addEventListener("change", () => {
+        document.querySelectorAll(".shift-checkbox").forEach((checkbox) => {
+            checkbox.checked = selectAll.checked;
+        });
+    });
+}
+
+function setupBulkDelete() {
+    document.querySelectorAll(".teamshifts-bulk-delete-btn").forEach((button) => {
+        button.addEventListener("click", (event) => {
+            event.preventDefault();
+
+            const selectedCount = document.querySelectorAll(".shift-checkbox:checked").length;
+            if (selectedCount === 0) {
+                window.alert(gettext("Please select at least one shift."));
+                return;
+            }
+
+            const confirmMsg = gettext("Are you sure you want to delete the selected shifts?");
+            if (typeof window.showConfirmDialog === "function") {
+                window
+                    .showConfirmDialog({ message: confirmMsg })
+                    .then((confirmed) => {
+                        if (confirmed) {
+                            button.form.requestSubmit(button);
+                        }
+                    });
+            } else if (window.confirm(confirmMsg)) {
+                button.form.requestSubmit(button);
+            }
+        });
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    setupSelectAll();
+    setupBulkDelete();
+});

--- a/teamshifts/static/teamshifts/shifts.js
+++ b/teamshifts/static/teamshifts/shifts.js
@@ -2,6 +2,56 @@ function gettext(msgid) {
     return typeof window.gettext === "function" ? window.gettext(msgid) : msgid;
 }
 
+function getI18n() {
+    const el = document.querySelector("[data-teamshifts-shifts-i18n]");
+    return el ? el.dataset : {};
+}
+
+function setCancelButtonHidden(hidden) {
+    const cancelBtn = document.getElementById("pretix-confirm-dialog-cancel");
+    if (cancelBtn) {
+        cancelBtn.classList.toggle("teamshifts-dialog-cancel-hidden", hidden);
+    }
+}
+
+function showAlertDialog(message) {
+    const i18n = getI18n();
+
+    if (typeof window.showConfirmDialog !== "function") {
+        window.alert(message);
+        return Promise.resolve();
+    }
+
+    setCancelButtonHidden(true);
+    return window
+        .showConfirmDialog({
+            message,
+            title: i18n.confirmTitle || gettext("Please confirm"),
+            confirmLabel: i18n.okLabel || gettext("OK"),
+            cancelLabel: i18n.cancelLabel || gettext("Cancel"),
+            confirmClass: "btn-primary",
+        })
+        .finally(() => {
+            setCancelButtonHidden(false);
+        });
+}
+
+function refreshSelectedCount() {
+    const checked = document.querySelectorAll(".shift-checkbox:checked").length;
+    const badge = document.querySelector("[data-shift-selected-count]");
+    const i18n = getI18n();
+    if (!badge) {
+        return;
+    }
+    if (checked > 0) {
+        badge.textContent = `${checked} ${i18n.selected || gettext("selected")}`;
+        badge.hidden = false;
+    } else {
+        badge.textContent = "";
+        badge.hidden = true;
+    }
+}
+
 function setupSelectAll() {
     const selectAll = document.getElementById("select-all");
     if (!selectAll) {
@@ -12,24 +62,39 @@ function setupSelectAll() {
         document.querySelectorAll(".shift-checkbox").forEach((checkbox) => {
             checkbox.checked = selectAll.checked;
         });
+        refreshSelectedCount();
+    });
+}
+
+function setupCheckboxes() {
+    document.querySelectorAll(".shift-checkbox").forEach((checkbox) => {
+        checkbox.addEventListener("change", refreshSelectedCount);
     });
 }
 
 function setupBulkDelete() {
+    const i18n = getI18n();
+
     document.querySelectorAll(".teamshifts-bulk-delete-btn").forEach((button) => {
         button.addEventListener("click", (event) => {
             event.preventDefault();
 
             const selectedCount = document.querySelectorAll(".shift-checkbox:checked").length;
             if (selectedCount === 0) {
-                window.alert(gettext("Please select at least one shift."));
+                showAlertDialog(i18n.selectOne || gettext("Please select at least one shift."));
                 return;
             }
 
             const confirmMsg = gettext("Are you sure you want to delete the selected shifts?");
             if (typeof window.showConfirmDialog === "function") {
                 window
-                    .showConfirmDialog({ message: confirmMsg })
+                    .showConfirmDialog({
+                        message: confirmMsg,
+                        title: gettext("Please confirm"),
+                        confirmLabel: gettext("Confirm"),
+                        cancelLabel: gettext("Cancel"),
+                        confirmClass: "btn-danger",
+                    })
                     .then((confirmed) => {
                         if (confirmed) {
                             button.form.requestSubmit(button);
@@ -44,5 +109,7 @@ function setupBulkDelete() {
 
 document.addEventListener("DOMContentLoaded", () => {
     setupSelectAll();
+    setupCheckboxes();
     setupBulkDelete();
+    refreshSelectedCount();
 });

--- a/teamshifts/static/teamshifts/teamshifts.css
+++ b/teamshifts/static/teamshifts/teamshifts.css
@@ -106,6 +106,16 @@ label .optional {
     padding-right: 0;
 }
 
+.teamshifts-selected-count {
+    margin: 0 0 6px 0;
+    color: #555;
+    font-size: 13px;
+}
+
+.teamshifts-dialog-cancel-hidden {
+    display: none !important;
+}
+
 .teamshifts-detail-header-container {
     margin-bottom: 20px;
 }

--- a/teamshifts/templates/teamshifts/shifts.html
+++ b/teamshifts/templates/teamshifts/shifts.html
@@ -12,8 +12,8 @@
 {% block teamshifts_header %}
   <h1>
     {% trans "Shifts" %}
-    {% if total_shift_count is not None %}
-      <span class="badge">{{ total_shift_count }}</span>
+    {% if page_obj.paginator.count is not None %}
+      <span class="badge">{{ page_obj.paginator.count }}</span>
     {% endif %}
   </h1>
 {% endblock %}
@@ -88,10 +88,6 @@
                             <i class="fa fa-trash"></i>
                         </a>
                     </td>
-                </tr>
-            {% empty %}
-                <tr>
-                    <td colspan="7" class="text-center">{% trans "No shifts created yet." %}</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/teamshifts/templates/teamshifts/shifts.html
+++ b/teamshifts/templates/teamshifts/shifts.html
@@ -10,12 +10,7 @@
 {% block title %}{% trans "Shifts" %} :: {{ request.event.name }}{% endblock %}
 
 {% block teamshifts_header %}
-  <h1>
-    {% trans "Shifts" %}
-    {% if page_obj.paginator.count is not None %}
-      <span class="badge">{{ page_obj.paginator.count }}</span>
-    {% endif %}
-  </h1>
+  <h1>{% trans "Shifts" %}</h1>
 {% endblock %}
 
 {% block teamshifts_content %}
@@ -36,6 +31,9 @@
     <form method="post" action="{% url 'plugins:teamshifts:shift_bulk_delete' organizer=request.organizer.slug event=request.event.slug %}" id="bulk-action-form">
       {% csrf_token %}
     </form>
+    {% if can_manage_shifts %}
+      <p class="teamshifts-selected-count text-muted" data-shift-selected-count hidden></p>
+    {% endif %}
     <div class="table-responsive">
         <table class="table table-hover table-striped">
             <thead>
@@ -99,4 +97,11 @@
         <p>{% trans "No shifts created yet." %}</p>
     </div>
   {% endif %}
+
+  <div data-teamshifts-shifts-i18n
+       data-confirm-title="{% trans 'Please confirm' %}"
+       data-ok-label="{% trans 'OK' %}"
+       data-select-one="{% trans 'Please select at least one shift.' %}"
+       data-selected="{% trans 'selected' %}"
+       hidden></div>
 {% endblock %}

--- a/teamshifts/templates/teamshifts/shifts.html
+++ b/teamshifts/templates/teamshifts/shifts.html
@@ -1,22 +1,50 @@
 {% extends "teamshifts/base.html" %}
 {% load i18n %}
+{% load static %}
+
+{% block custom_header %}
+    {{ block.super }}
+    <script type="module" src="{% static 'teamshifts/shifts.js' %}"></script>
+{% endblock %}
 
 {% block title %}{% trans "Shifts" %} :: {{ request.event.name }}{% endblock %}
 
 {% block teamshifts_header %}
-  <h1>{% trans "Shifts" %}</h1>
+  <h1>
+    {% trans "Shifts" %}
+    {% if total_shift_count is not None %}
+      <span class="badge">{{ total_shift_count }}</span>
+    {% endif %}
+  </h1>
 {% endblock %}
 
 {% block teamshifts_content %}
-  <p class="text-right">
-    <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary">
-      <i class="fa fa-plus"></i> {% trans "Create Shift" %}
-    </a>
-  </p>
-  <div class="table-responsive">
+  <div class="teamshifts-filter-bar clearfix">
+    <div class="pull-right">
+      {% if shifts and can_manage_shifts %}
+        <button type="submit" form="bulk-action-form" class="btn btn-danger teamshifts-bulk-delete-btn">
+          <span class="fa fa-trash"></span> {% trans "Delete selected" %}
+        </button>
+      {% endif %}
+      <a href="{% url 'plugins:teamshifts:shift_create' organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-primary">
+        <i class="fa fa-plus"></i> {% trans "Create Shift" %}
+      </a>
+    </div>
+  </div>
+
+  {% if shifts %}
+    <form method="post" action="{% url 'plugins:teamshifts:shift_bulk_delete' organizer=request.organizer.slug event=request.event.slug %}" id="bulk-action-form">
+      {% csrf_token %}
+    </form>
+    <div class="table-responsive">
         <table class="table table-hover table-striped">
             <thead>
             <tr>
+                <th class="teamshifts-select-all-col">
+                    {% if can_manage_shifts %}
+                    <input type="checkbox" id="select-all" title="{% trans 'Select all' %}" aria-label="{% trans 'Select all' %}">
+                    {% endif %}
+                </th>
                 <th>{% trans "Name" %}</th>
                 <th>{% trans "Location" %}</th>
                 <th>{% trans "Roles" %}</th>
@@ -28,6 +56,11 @@
             <tbody>
             {% for shift in shifts %}
                 <tr>
+                    <td class="teamshifts-checkbox-cell">
+                        {% if can_manage_shifts %}
+                        <input type="checkbox" name="shift_ids" value="{{ shift.pk }}" form="bulk-action-form" class="shift-checkbox" aria-label="{% trans 'Select shift' %}">
+                        {% endif %}
+                    </td>
                     <td>
                         {% if shift.name %}
                             {{ shift.name }}
@@ -58,10 +91,16 @@
                 </tr>
             {% empty %}
                 <tr>
-                    <td colspan="5" class="text-center">{% trans "No shifts created yet." %}</td>
+                    <td colspan="7" class="text-center">{% trans "No shifts created yet." %}</td>
                 </tr>
             {% endfor %}
             </tbody>
         </table>
     </div>
+    {% include "pretixcontrol/pagination.html" %}
+  {% else %}
+    <div class="empty-collection">
+        <p>{% trans "No shifts created yet." %}</p>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -98,6 +98,11 @@ urlpatterns = [
         name="shift_edit",
     ),
     path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/shifts/bulk-delete/",
+        views.BulkShiftDeleteView.as_view(),
+        name="shift_bulk_delete",
+    ),
+    path(
         "teamshifts/event/<orgslug:organizer>/<slug:event>/shifts/<int:pk>/delete/",
         views.ShiftDeleteView.as_view(),
         name="shift_delete",

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1380,7 +1380,7 @@ class ShiftListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, Pagina
     def get_queryset(self):
         event = self.request.event
         with scope(event=event):
-            return Shift.objects.filter(event=event).select_related("location").prefetch_related("role_assignments__role").order_by("start_time")
+            return Shift.objects.filter(event=event).select_related("location").prefetch_related("role_assignments__role").order_by("start_time", "pk")
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1399,7 +1399,7 @@ class BulkShiftDeleteView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, 
     def post(self, request, *args, **kwargs):
         event = request.event
         with scope(event=event):
-            shift_ids = request.POST.getlist("shift_ids")
+            shift_ids = [int(v) for v in request.POST.getlist("shift_ids") if str(v).strip().isdigit()]
             if not shift_ids:
                 messages.warning(request, _("No shifts selected."))
                 return redirect(

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1374,7 +1374,6 @@ class ShiftListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, Pagina
     permission = "can_teamshifts_create_shifts"
     template_name = "teamshifts/shifts.html"
     context_object_name = "shifts"
-    paginate_by = 50
     DEFAULT_PAGINATION = 50
 
     def get_queryset(self):
@@ -1384,11 +1383,8 @@ class ShiftListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, Pagina
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        event = self.request.event
-        with scope(event=event):
-            ctx["total_shift_count"] = Shift.objects.filter(event=event).count()
         ctx["can_manage_shifts"] = has_teamshifts_permission(
-            self.request.user, self.request.organizer, event, "can_teamshifts_create_shifts", request=self.request
+            self.request.user, self.request.organizer, self.request.event, "can_teamshifts_create_shifts", request=self.request
         )
         return ctx
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1370,16 +1370,73 @@ class ShiftLocationDeleteView(PluginActiveMixin, TeamShiftsPermissionRequiredMix
         return redirect("plugins:teamshifts:locations", organizer=request.organizer.slug, event=request.event.slug)
 
 
-class ShiftListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, TemplateView):
+class ShiftListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, PaginationMixin, ListView):
     permission = "can_teamshifts_create_shifts"
     template_name = "teamshifts/shifts.html"
+    context_object_name = "shifts"
+    paginate_by = 50
+    DEFAULT_PAGINATION = 50
+
+    def get_queryset(self):
+        event = self.request.event
+        with scope(event=event):
+            return Shift.objects.filter(event=event).select_related("location").prefetch_related("role_assignments__role").order_by("start_time")
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         event = self.request.event
         with scope(event=event):
-            ctx["shifts"] = list(Shift.objects.filter(event=event).select_related("location").prefetch_related("role_assignments__role").order_by("start_time"))
+            ctx["total_shift_count"] = Shift.objects.filter(event=event).count()
+        ctx["can_manage_shifts"] = has_teamshifts_permission(
+            self.request.user, self.request.organizer, event, "can_teamshifts_create_shifts", request=self.request
+        )
         return ctx
+
+
+class BulkShiftDeleteView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, View):
+    permission = "can_teamshifts_create_shifts"
+
+    def post(self, request, *args, **kwargs):
+        event = request.event
+        with scope(event=event):
+            shift_ids = request.POST.getlist("shift_ids")
+            if not shift_ids:
+                messages.warning(request, _("No shifts selected."))
+                return redirect(
+                    reverse(
+                        "plugins:teamshifts:shifts",
+                        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+                    )
+                )
+
+            with transaction.atomic():
+                shifts = Shift.objects.filter(event=event, pk__in=shift_ids)
+                count = shifts.count()
+                if count == 0:
+                    messages.warning(request, _("No shifts selected."))
+                    return redirect(
+                        reverse(
+                            "plugins:teamshifts:shifts",
+                            kwargs={"organizer": event.organizer.slug, "event": event.slug},
+                        )
+                    )
+                shifts.delete()
+
+            messages.success(
+                request,
+                ngettext(
+                    "%(count)d shift deleted.",
+                    "%(count)d shifts deleted.",
+                    count,
+                )
+                % {"count": count},
+            )
+            return redirect(
+                reverse(
+                    "plugins:teamshifts:shifts",
+                    kwargs={"organizer": event.organizer.slug, "event": event.slug},
+                )
+            )
 
 
 class ShiftCreateView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, TemplateView):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1383,8 +1383,9 @@ class ShiftListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, Pagina
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
+        event = self.request.event
         ctx["can_manage_shifts"] = has_teamshifts_permission(
-            self.request.user, self.request.organizer, self.request.event, "can_teamshifts_create_shifts", request=self.request
+            self.request.user, self.request.organizer, event, "can_teamshifts_create_shifts", request=self.request
         )
         return ctx
 

--- a/tests/test_bulk_shift_delete.py
+++ b/tests/test_bulk_shift_delete.py
@@ -163,7 +163,7 @@ def test_shifts_list_pagination(orga_client, event, location):
     assert response.status_code == 200
     assert len(response.context["shifts"]) == 50
     assert response.context["is_paginated"] is True
-    assert response.context["total_shift_count"] == 55
+    assert response.context["page_obj"].paginator.count == 55
 
 
 @pytest.mark.django_db

--- a/tests/test_bulk_shift_delete.py
+++ b/tests/test_bulk_shift_delete.py
@@ -164,3 +164,22 @@ def test_shifts_list_pagination(orga_client, event, location):
     assert len(response.context["shifts"]) == 50
     assert response.context["is_paginated"] is True
     assert response.context["total_shift_count"] == 55
+
+
+@pytest.mark.django_db
+def test_bulk_delete_invalid_shift_ids_are_ignored(orga_client, event, shifts):
+    """Non-integer shift_id values must not cause a 500 error; they should be
+    treated as if no valid IDs were submitted, triggering the "no selection" path."""
+    url = reverse(
+        "plugins:teamshifts:shift_bulk_delete",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+    # Mix of non-integers that would cause ValueError if fed directly to pk__in
+    response = orga_client.post(url, {"shift_ids": ["abc", "", "1.5", "<script>"]}, follow=True)
+
+    # Must not 500; page renders after redirect
+    assert response.status_code == 200
+
+    # All shifts must remain untouched
+    with scope(event=event):
+        assert Shift.objects.filter(event=event).count() == 5

--- a/tests/test_bulk_shift_delete.py
+++ b/tests/test_bulk_shift_delete.py
@@ -1,0 +1,166 @@
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils.timezone import now
+from django_scopes import scope
+from eventyay.base.models import Event, Team
+
+from teamshifts.models import Shift, ShiftLocation
+
+
+@pytest.fixture
+def orga_client(client, event, user, settings):
+    settings.SITE_URL = "https://testserver"
+    with scope(event=event):
+        team = Team.objects.create(
+            organizer=event.organizer,
+            name="Orga Team",
+            can_change_event_settings=True,
+            all_events=True,
+        )
+        team.members.add(user)
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def non_orga_client(client, django_user_model, settings):
+    settings.SITE_URL = "https://testserver"
+    non_orga = django_user_model.objects.create_user(email="other@example.com", password="x")
+    client.force_login(non_orga)
+    return client
+
+
+@pytest.fixture
+def other_event(event):
+    with scope(event=event):
+        return Event.objects.create(
+            organizer=event.organizer,
+            name="Other Event",
+            slug="other-event",
+            date_from=now(),
+            plugins="teamshifts",
+        )
+
+
+@pytest.fixture
+def location(event):
+    with scope(event=event):
+        return ShiftLocation.objects.create(event=event, name="Stage A")
+
+
+@pytest.fixture
+def shifts(event, location):
+    with scope(event=event):
+        created = []
+        base_time = now() + timedelta(days=1)
+        for i in range(5):
+            start = base_time + timedelta(hours=i * 2)
+            end = start + timedelta(hours=2)
+            shift = Shift.objects.create(
+                event=event,
+                name=f"Shift {i}",
+                location=location,
+                start_time=start,
+                end_time=end,
+            )
+            created.append(shift)
+        return created
+
+
+@pytest.mark.django_db
+def test_bulk_delete_shifts_success(orga_client, event, shifts):
+    url = reverse(
+        "plugins:teamshifts:shift_bulk_delete",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+    to_delete = [shifts[0].pk, shifts[1].pk, shifts[2].pk]
+    response = orga_client.post(url, {"shift_ids": to_delete})
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse(
+        "plugins:teamshifts:shifts",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+
+    with scope(event=event):
+        remaining = list(Shift.objects.filter(event=event).values_list("pk", flat=True))
+        assert set(remaining) == {shifts[3].pk, shifts[4].pk}
+
+
+@pytest.mark.django_db
+def test_bulk_delete_no_selection_warning(orga_client, event, shifts):
+    url = reverse(
+        "plugins:teamshifts:shift_bulk_delete",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+    response = orga_client.post(url, {"shift_ids": []}, follow=True)
+
+    assert response.status_code == 200
+    with scope(event=event):
+        assert Shift.objects.filter(event=event).count() == 5
+
+
+@pytest.mark.django_db
+def test_bulk_delete_permission_denied(non_orga_client, event, shifts):
+    url = reverse(
+        "plugins:teamshifts:shift_bulk_delete",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+    response = non_orga_client.post(url, {"shift_ids": [shifts[0].pk]})
+    assert response.status_code in (403, 404)
+
+    with scope(event=event):
+        assert Shift.objects.filter(event=event).count() == 5
+
+
+@pytest.mark.django_db
+def test_bulk_delete_cross_event_isolation(orga_client, event, location, other_event):
+    with scope(event=other_event):
+        other_location = ShiftLocation.objects.create(event=other_event, name="Other Stage")
+        start = now() + timedelta(days=1)
+        other_shift = Shift.objects.create(
+            event=other_event,
+            name="Other Event Shift",
+            location=other_location,
+            start_time=start,
+            end_time=start + timedelta(hours=2),
+        )
+
+    url = reverse(
+        "plugins:teamshifts:shift_bulk_delete",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+    response = orga_client.post(url, {"shift_ids": [other_shift.pk]})
+    assert response.status_code == 302
+
+    with scope(event=other_event):
+        assert Shift.objects.filter(event=other_event, pk=other_shift.pk).exists()
+
+
+@pytest.mark.django_db
+def test_shifts_list_pagination(orga_client, event, location):
+    with scope(event=event):
+        base_time = now() + timedelta(days=1)
+        shifts_to_create = [
+            Shift(
+                event=event,
+                name=f"Paginated Shift {i}",
+                location=location,
+                start_time=base_time + timedelta(hours=i),
+                end_time=base_time + timedelta(hours=i + 1),
+            )
+            for i in range(55)
+        ]
+        Shift.objects.bulk_create(shifts_to_create)
+
+    url = reverse(
+        "plugins:teamshifts:shifts",
+        kwargs={"organizer": event.organizer.slug, "event": event.slug},
+    )
+    response = orga_client.get(url)
+    assert response.status_code == 200
+    assert len(response.context["shifts"]) == 50
+    assert response.context["is_paginated"] is True
+    assert response.context["total_shift_count"] == 55


### PR DESCRIPTION
Closes #120

## Changes

- Added pagination with 50 shifts per page
- Added checkbox selection for shifts
- Added select-all functionality for the current page
- Added bulk shift deletion with confirmation
- Added event-scoped bulk deletion
- Added permission checks for bulk deletion
- Added tests for bulk deletion, permissions, event isolation, and pagination

## Screenshots 

<img width="1458" height="741" alt="Screenshot 2026-08-26 at 7 54 47 PM" src="https://github.com/user-attachments/assets/5a3c3379-160e-45b0-9f84-5b5d86d65614" />

<img width="1458" height="741" alt="Screenshot 2026-08-26 at 7 54 56 PM" src="https://github.com/user-attachments/assets/43c6e398-c0d4-4ae2-bf46-baf6cad22ff1" />

<img width="1458" height="741" alt="Screenshot 2026-08-26 at 7 55 09 PM" src="https://github.com/user-attachments/assets/c663b67f-9eab-4283-abea-4f581f8a5918" />


## Testing

- Tested bulk deletion
- Tested pagination
- Tested permission handling
- Tested cross-event isolation

## Summary by Sourcery

Enable event-scoped bulk shift deletion with permission checks alongside paginated shift management.

New Features:
- Add paginated shift listings with a 50-shift page size and total-count display.
- Enable selecting shifts on the current page and deleting them in bulk with confirmation.
- Scope bulk deletion to the active event and restrict it to users with shift-management permissions.

Bug Fixes:
- Prevent invalid or cross-event shift identifiers from causing unintended deletions or errors.

Tests:
- Add coverage for bulk deletion, empty and invalid selections, permissions, event isolation, and pagination.