### PR TITLE
fix(migrations): Renumber conflicting 0018 migration to 0019

### DIFF
--- a/teamshifts/migrations/0019_member_added_by_organizer.py
+++ b/teamshifts/migrations/0019_member_added_by_organizer.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("teamshifts", "0017_cfm_private_secret_link"),
+        ("teamshifts", "0018_cfm_shift_schedule_published"),
     ]
 
     operations = [


### PR DESCRIPTION
### What does this PR do?

Resolves a migration conflict in the `teamshifts` app caused by multiple leaf nodes in the migration graph:
- `0018_cfm_shift_schedule_published`
- `0018_member_added_by_organizer`

This was fixed by renumbering `0018_member_added_by_organizer` to `0019_member_added_by_organizer` and updating its dependencies to follow `0018_cfm_shift_schedule_published`.

This conflict was causing downstream test failures in other plugins (like `eventyay-interpretation`) when they attempted to run `makemigrations` or `migrate` against the unified test environment.

### Screenshots
N/A - Database migration fix.