### PR TITLE
fix: render Tiptap description HTML instead of escaping it

### DIFF
--- a/teamshifts/templates/teamshifts/locations.html
+++ b/teamshifts/templates/teamshifts/locations.html
@@ -1,6 +1,7 @@
 {% extends "teamshifts/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load rich_text %}
 
 {% block title %}{% trans "Locations" %} :: {{ request.event.name }}{% endblock %}
 
@@ -32,7 +33,7 @@
           {% for location in locations %}
             <tr>
               <td><strong>{{ location.name }}</strong></td>
-              <td class='text-muted'>{{ location.description|default:"—" }}</td>
+              <td class='text-muted'>{% if location.description %}{{ location.description|rich_text }}{% else %}—{% endif %}</td>
               <td class='text-right flip'>
                 <a href='{% url "plugins:teamshifts:location_edit" organizer=request.organizer.slug event=request.event.slug pk=location.pk %}' class='btn btn-default btn-sm'>
                   <span class='fa fa-edit'></span> {% trans "Edit" %}

--- a/teamshifts/templates/teamshifts/roles.html
+++ b/teamshifts/templates/teamshifts/roles.html
@@ -1,6 +1,7 @@
 {% extends "teamshifts/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load rich_text %}
 
 {% block title %}{% trans "Team Roles" %} :: {{ request.event.name }}{% endblock %}
 
@@ -36,7 +37,7 @@
                   <span class='label label-success'>{% trans "Open" %}</span>
                 {% endif %}
               </td>
-              <td class='text-muted'>{{ role.description|default:"—" }}</td>
+              <td class='text-muted'>{% if role.description %}{{ role.description|rich_text }}{% else %}—{% endif %}</td>
               <td></td>
               <td class='text-right flip'>
                 <a href='{% url "plugins:teamshifts:role_edit" organizer=request.organizer.slug event=request.event.slug pk=role.pk %}'

--- a/teamshifts/templates/teamshifts/shift_detail.html
+++ b/teamshifts/templates/teamshifts/shift_detail.html
@@ -1,6 +1,7 @@
 {% extends "pretixpresale/event/base.html" %}
 {% load i18n %}
 {% load static %}
+{% load rich_text %}
 
 {% block custom_header %}
   {{ block.super }}
@@ -33,7 +34,7 @@
         {% if shift.description %}
         <tr>
           <th class="ts-detail-label">{% trans "Description" %}</th>
-          <td>{{ shift.description }}</td>
+          <td>{{ shift.description|rich_text }}</td>
         </tr>
         {% endif %}
       </tbody>

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,5 +1,7 @@
 import pytest
+from django.urls import reverse
 from django_scopes import scope
+from eventyay.base.models import Team
 
 from teamshifts.forms import TeamRoleForm
 from teamshifts.models import TeamRole
@@ -30,3 +32,28 @@ def test_teamrole_form_validates_open_role(event):
         assert form.is_valid()
         role = form.save()
         assert role.is_restricted is False
+
+
+@pytest.mark.django_db
+def test_roles_list_renders_tiptap_html_description(client, event, user, settings):
+    settings.SITE_URL = "https://testserver"
+    with scope(event=event):
+        team = Team.objects.create(
+            organizer=event.organizer,
+            name="Orga Team",
+            can_change_event_settings=True,
+            all_events=True,
+        )
+        team.members.add(user)
+        TeamRole.objects.create(
+            event=event,
+            name="Registration",
+            description="<p>Assist attendees with <strong>check-in</strong>.</p>",
+        )
+    client.force_login(user)
+
+    url = reverse("plugins:teamshifts:roles", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"&lt;p&gt;" not in response.content
+    assert b"<strong>check-in</strong>" in response.content

--- a/tests/test_shift_locations.py
+++ b/tests/test_shift_locations.py
@@ -164,3 +164,18 @@ def test_location_delete_other_event_returns_404(orga_client, event, user, setti
     )
     response = orga_client.post(url)
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_location_list_renders_tiptap_html_description(orga_client, event):
+    with scope(event=event):
+        loc = ShiftLocation.objects.create(
+            event=event,
+            name="Tiptap Hall",
+            description="<p>Assist attendees with <strong>check-in</strong>.</p>",
+        )
+    url = reverse("plugins:teamshifts:locations", kwargs={"organizer": event.organizer.slug, "event": event.slug})
+    response = orga_client.get(url)
+    assert response.status_code == 200
+    assert b"&lt;p&gt;" not in response.content
+    assert b"<strong>check-in</strong>" in response.content


### PR DESCRIPTION
Closes #115 

#### Summary
Role, location, and shift descriptions saved via the shared Tiptap editor are stored as HTML (e.g. `<p>...</p>`). `roles.html`, `locations.html`, and `shift_detail.html` printed these fields directly, so Django's auto-escaping showed raw `<p>` tags to organizers instead of rendered text.

#### Fix
Apply the `rich_text` filter to these three templates, matching the pattern already used in `apply.html` and the CfM description preview.

#### Testing
- Added regression tests for the roles and locations list views with
  HTML-bearing descriptions; verified they fail on the old templates and
  pass with the fix.


https://github.com/user-attachments/assets/0464deec-0525-4be0-ac1b-e74e55e01c05

## Summary by Sourcery

Render shared-editor descriptions as formatted HTML across team shift views.

Bug Fixes:
- Render Tiptap-authored HTML descriptions correctly in role, location, and shift detail views instead of displaying escaped markup.

Tests:
- Add regression coverage confirming HTML descriptions render as formatted content in role and location lists.