### PR TITLE
Fix email template preview line breaks and 404 on new events

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -48,12 +48,6 @@ _BLOCK_TAG_RE = re.compile(r"^\s*<(p|ul|ol|blockquote|div|h[1-6])[\s>]", re.IGNO
 
 
 def plain_text_to_html(text: str) -> str:
-    """Convert plain text with ``\\n`` line separators into ``<p>`` blocks.
-
-    If the text already starts with a block-level HTML tag it is returned
-    unchanged so that content previously saved from the Tiptap editor is
-    not double-wrapped.
-    """
     if not text or _BLOCK_TAG_RE.match(text):
         return text
     paragraphs = re.split(r"\n{2,}", text)
@@ -67,14 +61,6 @@ def plain_text_to_html(text: str) -> str:
 
 
 class _HtmlNormalizingEmailWidget(I18nEmailEditorWidget):
-    """I18nEmailEditorWidget that converts plain-text values to ``<p>`` HTML.
-
-    The Tiptap editor treats raw text with ``\\n`` as whitespace and collapses
-    it into a single paragraph.  This subclass ensures the textarea always
-    contains block-level HTML so that line breaks survive the round-trip
-    through the editor.
-    """
-
     def decompress(self, value):
         values = super().decompress(value)
         return [plain_text_to_html(v) if v else v for v in values]

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -48,8 +48,11 @@ _BLOCK_TAG_RE = re.compile(r"^\s*<(p|ul|ol|blockquote|div|h[1-6])[\s>]", re.IGNO
 
 
 def plain_text_to_html(text: str) -> str:
-    if not text or _BLOCK_TAG_RE.match(text):
+    if not text:
         return text
+    if "data-variable=" in text or _BLOCK_TAG_RE.match(text):
+        return text
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     paragraphs = re.split(r"\n{2,}", text)
     parts = []
     for para in paragraphs:

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -44,13 +44,11 @@ def format_datetime_local(dt):
 
 EMAIL_PLACEHOLDERS = ["full_name", "event_name", "role_name", "event_dates", "event_location", "shift_schedule_url"]
 
-_BLOCK_TAG_RE = re.compile(r"^\s*<(p|ul|ol|blockquote|div|h[1-6])[\s>]", re.IGNORECASE)
-
 
 def plain_text_to_html(text: str) -> str:
     if not text:
         return text
-    if "data-variable=" in text or _BLOCK_TAG_RE.match(text):
+    if text.lstrip().startswith("<") or "data-variable=" in text:
         return text
     text = text.replace("\r\n", "\n").replace("\r", "\n")
     paragraphs = re.split(r"\n{2,}", text)

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -1,7 +1,9 @@
+import re
 from zoneinfo import ZoneInfo
 
 from django import forms
 from django.utils import timezone
+from django.utils.html import escape as html_escape
 from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 from django_scopes import scopes_disabled
@@ -41,6 +43,41 @@ def format_datetime_local(dt):
 
 
 EMAIL_PLACEHOLDERS = ["full_name", "event_name", "role_name", "event_dates", "event_location", "shift_schedule_url"]
+
+_BLOCK_TAG_RE = re.compile(r"^\s*<(p|ul|ol|blockquote|div|h[1-6])[\s>]", re.IGNORECASE)
+
+
+def plain_text_to_html(text: str) -> str:
+    """Convert plain text with ``\\n`` line separators into ``<p>`` blocks.
+
+    If the text already starts with a block-level HTML tag it is returned
+    unchanged so that content previously saved from the Tiptap editor is
+    not double-wrapped.
+    """
+    if not text or _BLOCK_TAG_RE.match(text):
+        return text
+    paragraphs = re.split(r"\n{2,}", text)
+    parts = []
+    for para in paragraphs:
+        stripped = para.strip()
+        if stripped:
+            inner = html_escape(stripped).replace("\n", "<br>")
+            parts.append(f"<p>{inner}</p>")
+    return "".join(parts) if parts else text
+
+
+class _HtmlNormalizingEmailWidget(I18nEmailEditorWidget):
+    """I18nEmailEditorWidget that converts plain-text values to ``<p>`` HTML.
+
+    The Tiptap editor treats raw text with ``\\n`` as whitespace and collapses
+    it into a single paragraph.  This subclass ensures the textarea always
+    contains block-level HTML so that line breaks survive the round-trip
+    through the editor.
+    """
+
+    def decompress(self, value):
+        values = super().decompress(value)
+        return [plain_text_to_html(v) if v else v for v in values]
 
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):
@@ -392,7 +429,7 @@ class EmailTemplateForm(forms.ModelForm):
         self.fields["body"].required = False
         if locales:
             self.fields["subject"].widget = I18nTextInput(locales=locales, field=self.fields["subject"])
-            self.fields["body"].widget = I18nEmailEditorWidget(
+            self.fields["body"].widget = _HtmlNormalizingEmailWidget(
                 locales=locales,
                 field=self.fields["body"],
                 placeholders=EMAIL_PLACEHOLDERS,
@@ -415,7 +452,7 @@ class CustomEmailTemplateForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if locales:
             self.fields["subject"].widget = I18nTextInput(locales=locales, field=self.fields["subject"])
-            self.fields["body"].widget = I18nEmailEditorWidget(
+            self.fields["body"].widget = _HtmlNormalizingEmailWidget(
                 locales=locales,
                 field=self.fields["body"],
                 placeholders=EMAIL_PLACEHOLDERS,
@@ -438,7 +475,7 @@ class EmailComposeForm(forms.Form):
         )
         self.fields["message"] = I18nFormField(
             label=_("Message"),
-            widget=I18nEmailEditorWidget,
+            widget=_HtmlNormalizingEmailWidget,
             required=True,
             locales=locales,
             widget_kwargs={
@@ -489,7 +526,7 @@ class EmailQueueEditForm(forms.ModelForm):
         self._event = event
         if event is not None:
             locales = list(event.settings.get("locales") or [event.settings.locale])
-            self.fields["message"].widget = I18nEmailEditorWidget(
+            self.fields["message"].widget = _HtmlNormalizingEmailWidget(
                 locales=locales,
                 field=self.fields["message"],
                 placeholders=EMAIL_PLACEHOLDERS,

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -353,10 +353,7 @@ class EmailTemplateListView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin
         event = request.event
         locales = event.settings.locales
         with scope(event=event):
-            try:
-                cfm = event.call_for_team_members
-            except CallForTeamMembers.DoesNotExist:
-                raise Http404 from None
+            cfm, _created = CallForTeamMembers.objects.get_or_create(event=event)
 
         from .mail.default_templates import get_default_template
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -18,16 +18,16 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.formats import date_format
-from django.utils.html import strip_tags
+from django.utils.html import escape, strip_tags
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import now
 from django.utils.translation import get_language, get_language_info, gettext_lazy as _, ngettext
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import DeleteView, FormView, ListView, TemplateView, View
 from django_scopes import scope, scopes_disabled
-from eventyay.base.i18n import LazyI18nString
+from eventyay.base.i18n import LazyI18nString, language
 from eventyay.base.models import Event, User
-from eventyay.base.templatetags.rich_text import rich_text
+from eventyay.base.templatetags.rich_text import compile_email_body, rich_text
 from eventyay.common.text.phrases import phrases
 from eventyay.control.views import PaginationMixin
 
@@ -480,15 +480,8 @@ class EmailTemplatePreviewView(PluginActiveMixin, TeamShiftsPermissionRequiredMi
     permission = "can_teamshifts_send_emails"
 
     def post(self, request, *args, **kwargs):
-        from collections import defaultdict
-
-        from eventyay.base.i18n import language
-        from eventyay.base.templatetags.rich_text import markdown_compile_email
-
         event = request.event
         event_locales = list(event.settings.locales)
-        from django.utils.html import escape
-
         region = event.settings.region
 
         sample_values = defaultdict(
@@ -509,7 +502,7 @@ class EmailTemplatePreviewView(PluginActiveMixin, TeamShiftsPermissionRequiredMi
                 lambda m: f'<span class="placeholder">{escape(sample_values.get(m.group(1), m.group(0)))}</span>',
                 text,
             )
-            return markdown_compile_email(highlighted)
+            return compile_email_body(highlighted)
 
         body_values = request.POST.getlist("body")
         previews = {}


### PR DESCRIPTION
Closes #124 

#### Summary

Fixes the TeamShifts email template editor so line breaks survive editing/preview, and stops the template page from throwing a 404 on freshly created events.

#### Changes

- **Use `compile_email_body` in the preview view** instead of `markdown_compile_email`. It auto-detects plain-text vs HTML content and matches the actual email sending pipeline (`TemplateBasedMailRenderer`).
- **Add `_HtmlNormalizingEmailWidget`** that converts legacy plain-text bodies (with `\n` separators) into `<p>`/`<br>` HTML during `decompress()`, so Tiptap receives proper block-level HTML on load. Content already saved as HTML is passed through unchanged. Applied to `EmailTemplateForm`, `CustomEmailTemplateForm`, `EmailComposeForm`, and `EmailQueueEditForm`.
- **Auto-create the CFM** in `EmailTemplateListView` with `get_or_create`, matching the pattern already used by the CFM settings and apply views.



https://github.com/user-attachments/assets/7dcca20d-1ab1-427f-8be3-e9f68fc74969




#### Risk and Rollback

Low risk, scoped to the TeamShifts email template forms and preview view. Rollback is a straightforward revert of the three commits; no migrations or schema changes involved.

#### Notes

- The `html_escape` in `plain_text_to_html` only runs on legacy plain-text bodies; it does not conflict with the description-field rich-text rendering from #123 , which is a separate template-rendering path.

## Summary by Sourcery

Fix TeamShifts email template rendering and initialization so previews retain content formatting and new events open correctly.

Bug Fixes:
- Preserve line breaks and formatting when loading and previewing email template content, including legacy plain-text bodies.
- Prevent newly created events from returning a 404 when opening the TeamShifts email template page.

Enhancements:
- Align email template previews with the production email rendering pipeline and normalize localized email editor content consistently across template, compose, and queue forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plain-text email content is automatically formatted for HTML delivery, including paragraphs and line breaks.
  - Existing HTML-formatted content remains unchanged.
  - Email previews now use the same rendering behavior as sent messages.

- **Bug Fixes**
  - Email template panels now open successfully when a call-for-team-members record has not yet been created, instead of showing an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->