### PR TITLE
Fix 404 for anonymous users on public Call pages

### DIFF
--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -1,48 +1,57 @@
 from django.urls import path
 from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
+from eventyay.multidomain import event_url
 
 from . import certificate_views, views
 
 event_patterns = [
-    path(
-        "teamshifts/apply/",
+    event_url(
+        r"^teamshifts/apply/$",
         views.PublicApplyView.as_view(),
         name="apply",
+        require_live=False,
     ),
-    path(
-        "teamshifts/apply/thanks/",
+    event_url(
+        r"^teamshifts/apply/thanks/$",
         views.PublicApplyThanksView.as_view(),
         name="apply_thanks",
+        require_live=False,
     ),
-    path(
-        "teamshifts/apply/s/<str:secret>/",
+    event_url(
+        r"^teamshifts/apply/s/(?P<secret>[^/]+)/$",
         views.PublicApplySecretView.as_view(),
         name="apply_secret",
+        require_live=False,
     ),
-    path(
-        "teamshifts/shifts/",
+    event_url(
+        r"^teamshifts/shifts/$",
         views.PublicShiftScheduleView.as_view(),
         name="public_shift_schedule",
+        require_live=False,
     ),
-    path(
-        "teamshifts/shifts/api/",
+    event_url(
+        r"^teamshifts/shifts/api/$",
         views.PublicShiftScheduleAPIView.as_view(),
         name="public_shift_schedule_api",
+        require_live=False,
     ),
-    path(
-        "teamshifts/shifts/<int:pk>/",
+    event_url(
+        r"^teamshifts/shifts/(?P<pk>\d+)/$",
         views.ShiftDetailView.as_view(),
         name="public_shift_detail",
+        require_live=False,
     ),
-    path(
-        "teamshifts/shifts/<int:pk>/claim/",
+    event_url(
+        r"^teamshifts/shifts/(?P<pk>\d+)/claim/$",
         views.ShiftClaimView.as_view(),
         name="public_shift_claim",
+        require_live=False,
     ),
-    path(
-        "teamshifts/shifts/<int:pk>/withdraw/",
+    event_url(
+        r"^teamshifts/shifts/(?P<pk>\d+)/withdraw/$",
         views.ShiftWithdrawView.as_view(),
         name="public_shift_withdraw",
+        require_live=False,
     ),
 ]
 


### PR DESCRIPTION
Closes #125 

#### Summary

Anonymous users clicking the "Call for Volunteers" (and other public TeamShifts links) were shown an HTTP 404 "Page not found" instead of being prompted to log in. This fix redirects unauthenticated visitors to the login page with a `?next=` back to the form, so they land on the apply form right after signing in.

#### Fix

Wrap the public `event_patterns` with `event_url(..., require_live=False)` from `eventyay.multidomain`. This is the framework's documented mechanism for public plugin URLs and is already used by the PayPal and Stripe plugins for their webhook endpoints. With the live check disabled at the routing layer, the views handle authentication themselves and redirect anonymous users to the login page.

Routes updated (all under `event_patterns`):
- `apply`, `apply_thanks`, `apply_secret`
- `public_shift_schedule`, `public_shift_schedule_api`
- `public_shift_detail`, `public_shift_claim`, `public_shift_withdraw`

No changes to the organizer-facing `urlpatterns` (dashboard, settings, etc.), which are permission-gated separately.

#### Risk and Rollback

Low risk. Change is confined to `teamshifts/urls.py` URL declarations. Rollback is a single-file revert. Public routes still enforce authentication and plugin-enabled checks inside their views; only the "event must be live" gate at the routing layer is lifted for these public pages.

#### Notes

`event_url()` uses regex patterns, so path converters were rewritten (`<int:pk>` → `(?P<pk>\d+)`, `<str:secret>` → `(?P<secret>[^/]+)`). Behavior and URL names are unchanged.

## Summary by Sourcery

Bug Fixes:
- Route public TeamShifts pages through the event URL handler without requiring the event to be live, allowing anonymous visitors to reach the views and be redirected to login instead of receiving a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated team-shift application, scheduling, details, claim, and withdrawal links to use event-based URLs.
  - Team-shift endpoints can now be accessed without requiring the event to be marked live.
  - Improved compatibility for secret values included in team-shift links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->