### PR TITLE
fix: strip HTML from shift location description in schedule tooltip

### DIFF
--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1,3 +1,4 @@
+import html as html_mod
 import json
 import logging
 import re
@@ -1782,7 +1783,7 @@ class ShiftScheduleTalksAPIView(PluginActiveMixin, TeamShiftsPermissionRequiredM
 
             locations = event.shift_locations.all()
             for loc in locations:
-                data["rooms"].append({"id": loc.id, "name": {"en": loc.name}, "description": {"en": strip_tags(loc.description) if loc.description else ""}})
+                data["rooms"].append({"id": loc.id, "name": {"en": loc.name}, "description": {"en": _html_to_plain(loc.description)}})
 
             shifts = event.shifts.all().prefetch_related(
                 "role_assignments__role",
@@ -2141,6 +2142,24 @@ def _shift_roles_payload(shift):
     return roles_data
 
 
+_BLOCK_TAG_RE = re.compile(
+    r"</?(?:address|article|aside|blockquote|dd|details|div|dl|dt|figcaption"
+    r"|figure|footer|h[1-6]|header|li|main|nav|ol|p|pre|section|summary"
+    r"|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>|<br\s*/?>",
+    re.IGNORECASE,
+)
+
+
+def _html_to_plain(value: str) -> str:
+    """Convert rich-text HTML to plain text for schedule tooltips."""
+    if not value:
+        return ""
+    text = _BLOCK_TAG_RE.sub("\n", value)
+    text = strip_tags(text)
+    text = html_mod.unescape(text)
+    return "\n".join(line.strip() for line in text.splitlines() if line.strip())
+
+
 def _shift_talk_payload(shift):
     duration = int((shift.end_time - shift.start_time).total_seconds() / 60) if shift.end_time and shift.start_time else 0
     return {
@@ -2264,7 +2283,7 @@ class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
                     {
                         "id": loc.id,
                         "name": {"en": loc.name},
-                        "description": {"en": strip_tags(loc.description) if loc.description else ""},
+                        "description": {"en": _html_to_plain(loc.description)},
                     }
                 )
 
@@ -2295,7 +2314,7 @@ class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
             {
                 "id": loc.id,
                 "name": {"en": loc.name},
-                "description": {"en": strip_tags(loc.description) if loc.description else ""},
+                "description": {"en": _html_to_plain(loc.description)},
             }
             for loc in locations
         ]

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -2145,7 +2145,7 @@ def _shift_roles_payload(shift):
 _BLOCK_TAG_RE = re.compile(
     r"</?(?:address|article|aside|blockquote|dd|details|div|dl|dt|figcaption"
     r"|figure|footer|h[1-6]|header|li|main|nav|ol|p|pre|section|summary"
-    r"|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>|<br\s*/?>",
+    r"|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>|<br\b[^>]*>",
     re.IGNORECASE,
 )
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -16,6 +16,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.formats import date_format
+from django.utils.html import strip_tags
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import now
 from django.utils.translation import get_language, get_language_info, gettext_lazy as _, ngettext
@@ -1781,7 +1782,7 @@ class ShiftScheduleTalksAPIView(PluginActiveMixin, TeamShiftsPermissionRequiredM
 
             locations = event.shift_locations.all()
             for loc in locations:
-                data["rooms"].append({"id": loc.id, "name": {"en": loc.name}, "description": {"en": loc.description or ""}})
+                data["rooms"].append({"id": loc.id, "name": {"en": loc.name}, "description": {"en": strip_tags(loc.description) if loc.description else ""}})
 
             shifts = event.shifts.all().prefetch_related(
                 "role_assignments__role",
@@ -2263,7 +2264,7 @@ class PublicShiftScheduleAPIView(PublicShiftScheduleMixin, View):
                     {
                         "id": loc.id,
                         "name": {"en": loc.name},
-                        "description": {"en": loc.description or ""},
+                        "description": {"en": strip_tags(loc.description) if loc.description else ""},
                     }
                 )
 
@@ -2294,7 +2295,7 @@ class PublicShiftScheduleView(PublicShiftScheduleMixin, TemplateView):
             {
                 "id": loc.id,
                 "name": {"en": loc.name},
-                "description": {"en": loc.description or ""},
+                "description": {"en": strip_tags(loc.description) if loc.description else ""},
             }
             for loc in locations
         ]


### PR DESCRIPTION
Closes #128 

The shift location description is edited with a Tiptap rich-text widget, so it stores HTML (e.g. `<p>...</p>`). When serialized to JSON for the schedule widget, this raw HTML was passed through unchanged. The shared `GridSchedule.vue` tooltip renders text via `{{ }}` interpolation, so the HTML tags showed up literally instead of being stripped.

Fix: apply `strip_tags()` to `loc.description` in all three schedule JSON serialization points in `views.py` (organizer editor API, public API, public page context). This matches how the talk schedule works — its `Room.description` is always plain text because the form uses a plain widget.

<img width="1162" height="769" alt="Screenshot 2026-09-04 at 2 14 42 PM" src="https://github.com/user-attachments/assets/91859b63-3657-403f-a1d4-aa68a55eb535" />



## Summary by Sourcery

Strip rich-text markup from shift location descriptions before exposing them to schedule consumers.

Bug Fixes:
- Prevent HTML markup from appearing literally in shift location descriptions shown in schedule tooltips and serialized schedule data.

Enhancements:
- Normalize rich-text shift location descriptions to clean, readable plain text across organizer, public API, and public page schedule data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shift-room descriptions now display as normalized plain text, with HTML formatting removed and entities decoded.
  * Line breaks between content blocks are preserved for clearer readability.
  * Empty lines are removed to prevent unnecessary spacing.
  * The improved formatting is applied consistently across all shift-room schedule views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->