### PR TITLE
Fix CFM description losing non-English locales on save and preview

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -73,9 +73,9 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
                 attrs={"data-tiptap-profile": "richtext"},
             )
             field.widget.enabled_locales = locales
-            locale_set = set(locales)
+            fields_by_locale = {f.locale: f for f in field.fields}
             field.locales = list(locales)
-            field.fields = [f for f in field.fields if f.locale in locale_set]
+            field.fields = [fields_by_locale[loc] for loc in locales if loc in fields_by_locale]
         if self._event:
             self.fields["deadline"].help_text = get_tz_help(self._event)
             if not self.initial.get("deadline"):

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -66,12 +66,16 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
         self._event = kwargs.pop("event", None)
         super().__init__(*args, **kwargs)
         if locales:
-            self.fields["description"].widget = I18nEmailEditorWidget(
+            field = self.fields["description"]
+            field.widget = I18nEmailEditorWidget(
                 locales=locales,
-                field=self.fields["description"],
+                field=field,
                 attrs={"data-tiptap-profile": "richtext"},
             )
-            self.fields["description"].widget.enabled_locales = locales
+            field.widget.enabled_locales = locales
+            locale_set = set(locales)
+            field.locales = list(locales)
+            field.fields = [f for f in field.fields if f.locale in locale_set]
         if self._event:
             self.fields["deadline"].help_text = get_tz_help(self._event)
             if not self.initial.get("deadline"):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -5,7 +5,6 @@ import secrets
 from datetime import timedelta
 
 import dateutil.parser
-from django.conf import settings as django_settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -122,8 +121,7 @@ class CFMSettingsView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, View
         if not isinstance(description, dict):
             description = dict.fromkeys(self.request.event.settings.locales, description or "")
 
-        event_locales = set(request.event.settings.locales)
-        description_previews = [(code, rich_text(description.get(code, ""))) for code, _name in django_settings.LANGUAGES if code in event_locales]
+        description_previews = [(code, rich_text(description.get(code, ""))) for code in request.event.settings.locales]
 
         return render(request, self.template_name, {"form": form, "cfm": cfm, "description_previews": description_previews})
 
@@ -147,8 +145,7 @@ class CFMSettingsView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, View
         if not isinstance(description, dict):
             description = dict.fromkeys(request.event.settings.locales, description or "")
 
-        event_locales = set(request.event.settings.locales)
-        description_previews = [(code, rich_text(description.get(code, ""))) for code, _name in django_settings.LANGUAGES if code in event_locales]
+        description_previews = [(code, rich_text(description.get(code, ""))) for code in request.event.settings.locales]
         return render(request, self.template_name, {"form": form, "cfm": cfm, "description_previews": description_previews})
 
 
@@ -244,16 +241,16 @@ class CFMDescriptionPreviewView(PluginActiveMixin, TeamShiftsPermissionRequiredM
     permission = "can_teamshifts_manage_applicants"
 
     def post(self, request, *args, **kwargs):
-        event_locales = set(request.event.settings.locales)
-        widget = CallForTeamMembersSettingsForm(locales=list(event_locales)).fields["description"].widget
+        event_locales = list(request.event.settings.locales)
+        widget = CallForTeamMembersSettingsForm(locales=event_locales).fields["description"].widget
         raw_values = widget.value_from_datadict(request.POST, request.FILES, "description")
         if not isinstance(raw_values, (list, tuple)):
             raw_values = [raw_values]
 
         msgs = {}
-        for index, (code, _name) in enumerate(django_settings.LANGUAGES):
-            if code in event_locales and index < len(raw_values):
-                text = raw_values[index]
+        for i, code in enumerate(event_locales):
+            if i < len(raw_values):
+                text = raw_values[i]
                 msgs[code] = str(rich_text(text)) if text else ""
 
         return JsonResponse({"msgs": msgs})


### PR DESCRIPTION
Closes #129 

**Cause**
The description field's widget was rebuilt with the event's locales, but the underlying `I18nFormField.locales` and sub-fields still used the full global `settings.LANGUAGES` list. This positional mismatch made `compress()` map values to the wrong locale codes (and crash with `IndexError`). The preview endpoint and preview blocks also iterated the global language list, causing dropped locales and wrong ordering.

**Fix**
- `forms.py`: sync `field.locales` and the sub-field list with the widget's event locales so save maps values to the correct locale codes.
- `views.py`: build the preview blocks and the preview AJAX response from `event.settings.locales` (event order) instead of the global `settings.LANGUAGES`; removed the now-unused import.

**Impact / Risk**
Low. Changes are confined to the CFM settings form and view; no model or migration changes. Verified via smoke tests that all locales map correctly and the container starts cleanly.



https://github.com/user-attachments/assets/eef4b475-0cd3-45cb-b4ba-62ca2e19200a



## Summary by Sourcery

Preserve event-configured locales throughout CFM description editing and preview flows.

Bug Fixes:
- Preserve event-specific locale mappings and ordering when saving, previewing, and rendering CFM descriptions, preventing dropped translations and locale indexing errors.

Enhancements:
- Align the internationalized description field with the locales configured for each event and remove reliance on the global language list in CFM views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event description and email previews now display only the locales configured for the event.
  * Locale options in team member settings are limited to the event’s available locales.
  * Improved consistency between configured locales and the content shown in previews and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->