### PR TITLE
fix: stop Tiptap HTML leaking as plain text in emails (#116)

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -498,6 +498,9 @@ class EmailComposeForm(forms.Form):
             input_formats=["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"],
         )
 
+    def clean_message(self):
+        return sanitize_i18n_email_html(self.cleaned_data.get("message"))
+
 
 class EmailQueueEditForm(forms.ModelForm):
     class Meta:
@@ -520,7 +523,7 @@ class EmailQueueEditForm(forms.ModelForm):
                 label=_("Message"),
                 widget=I18nEmailEditorWidget,
                 widget_kwargs={"placeholders": EMAIL_PLACEHOLDERS},
-                required=False,
+                required=True,
                 locales=locales,
                 initial=self.initial.get("message", getattr(self.instance, "message", None)),
             )

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -7,9 +7,12 @@ from django_countries import countries
 from django_scopes import scopes_disabled
 from django_scopes.forms import SafeModelChoiceField
 from eventyay.base.models import Event
+from eventyay.common.forms.fields import I18nEmailBodyFormField
 from eventyay.common.forms.widgets import I18nEmailEditorWidget, RichTextWidget
+from eventyay.common.sanitizers import sanitize_email_html
 from eventyay.control.forms import SplitDateTimeField, SplitDateTimePickerWidget
 from i18nfield.forms import I18nFormField, I18nTextInput
+from i18nfield.strings import LazyI18nString
 
 from .models import (
     CFM_BUILTIN_FIELD_KEYS,
@@ -41,6 +44,18 @@ def format_datetime_local(dt):
 
 
 EMAIL_PLACEHOLDERS = ["full_name", "event_name", "role_name", "event_dates", "event_location", "shift_schedule_url"]
+
+
+def sanitize_i18n_email_html(value):
+    """Sanitize Tiptap/email HTML stored in i18n string fields."""
+    if isinstance(value, LazyI18nString):
+        if isinstance(value.data, dict):
+            return LazyI18nString({locale: sanitize_email_html(text) if text else text for locale, text in value.data.items()})
+        if isinstance(value.data, str):
+            return LazyI18nString(sanitize_email_html(value.data) if value.data else value.data)
+    if isinstance(value, str):
+        return sanitize_email_html(value) if value else value
+    return value
 
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):
@@ -392,13 +407,19 @@ class EmailTemplateForm(forms.ModelForm):
         self.fields["body"].required = False
         if locales:
             self.fields["subject"].widget = I18nTextInput(locales=locales, field=self.fields["subject"])
-            self.fields["body"].widget = I18nEmailEditorWidget(
+            self.fields["body"] = I18nEmailBodyFormField(
+                label=_("Body"),
+                widget=I18nEmailEditorWidget,
+                widget_kwargs={"placeholders": EMAIL_PLACEHOLDERS},
+                required=False,
                 locales=locales,
-                field=self.fields["body"],
-                placeholders=EMAIL_PLACEHOLDERS,
+                initial=self.initial.get("body", getattr(self.instance, "body", None)),
             )
             for field_name in ("subject", "body"):
                 self.fields[field_name].widget.enabled_locales = locales
+
+    def clean_body(self):
+        return sanitize_i18n_email_html(self.cleaned_data.get("body"))
 
 
 class CustomEmailTemplateForm(forms.ModelForm):
@@ -415,13 +436,19 @@ class CustomEmailTemplateForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if locales:
             self.fields["subject"].widget = I18nTextInput(locales=locales, field=self.fields["subject"])
-            self.fields["body"].widget = I18nEmailEditorWidget(
+            self.fields["body"] = I18nEmailBodyFormField(
+                label=_("Body"),
+                widget=I18nEmailEditorWidget,
+                widget_kwargs={"placeholders": EMAIL_PLACEHOLDERS},
+                required=False,
                 locales=locales,
-                field=self.fields["body"],
-                placeholders=EMAIL_PLACEHOLDERS,
+                initial=self.initial.get("body", getattr(self.instance, "body", None)),
             )
             for field_name in ("subject", "body"):
                 self.fields[field_name].widget.enabled_locales = locales
+
+    def clean_body(self):
+        return sanitize_i18n_email_html(self.cleaned_data.get("body"))
 
 
 class EmailComposeForm(forms.Form):
@@ -436,7 +463,7 @@ class EmailComposeForm(forms.Form):
             required=True,
             locales=locales,
         )
-        self.fields["message"] = I18nFormField(
+        self.fields["message"] = I18nEmailBodyFormField(
             label=_("Message"),
             widget=I18nEmailEditorWidget,
             required=True,
@@ -489,10 +516,13 @@ class EmailQueueEditForm(forms.ModelForm):
         self._event = event
         if event is not None:
             locales = list(event.settings.get("locales") or [event.settings.locale])
-            self.fields["message"].widget = I18nEmailEditorWidget(
+            self.fields["message"] = I18nEmailBodyFormField(
+                label=_("Message"),
+                widget=I18nEmailEditorWidget,
+                widget_kwargs={"placeholders": EMAIL_PLACEHOLDERS},
+                required=False,
                 locales=locales,
-                field=self.fields["message"],
-                placeholders=EMAIL_PLACEHOLDERS,
+                initial=self.initial.get("message", getattr(self.instance, "message", None)),
             )
             for field_name in ("subject", "message"):
                 self.fields[field_name].widget.enabled_locales = locales
@@ -508,6 +538,9 @@ class EmailQueueEditForm(forms.ModelForm):
             "%Y-%m-%d %H:%M:%S",
             "%Y-%m-%d %H:%M",
         ]
+
+    def clean_message(self):
+        return sanitize_i18n_email_html(self.cleaned_data.get("message"))
 
 
 __all__ = [

--- a/teamshifts/services/email.py
+++ b/teamshifts/services/email.py
@@ -20,7 +20,7 @@ from ..tasks import send_queued_email
 
 logger = logging.getLogger(__name__)
 
-_HTML_BODY_RE = re.compile(r"(?i)</?(p|br|div|ul|ol|li|strong|b|em|i|u|span|a|blockquote)\b")
+_HTML_BODY_RE = re.compile(r"(?i)</?(p|br|div|ul|ol|li|strong|b|em|i|u|span|a|blockquote|h[1-6])\b")
 
 
 def looks_like_email_html(value: str) -> bool:

--- a/teamshifts/services/email.py
+++ b/teamshifts/services/email.py
@@ -1,7 +1,10 @@
 import logging
+import re
 from collections.abc import Iterable
+from html import unescape
 
 from django.db import transaction
+from django.utils.html import strip_tags
 from django_scopes import scope
 from eventyay.base.models import Event, User
 
@@ -16,6 +19,31 @@ from ..models import (
 from ..tasks import send_queued_email
 
 logger = logging.getLogger(__name__)
+
+_HTML_BODY_RE = re.compile(r"(?i)</?(p|br|div|ul|ol|li|strong|b|em|i|u|span|a|blockquote)\b")
+
+
+def looks_like_email_html(value: str) -> bool:
+    """Return True when *value* looks like Tiptap/email HTML rather than plain text."""
+    if not value or "<" not in value:
+        return False
+    return bool(_HTML_BODY_RE.search(value))
+
+
+def html_to_plain_text(html: str) -> str:
+    """Convert email HTML to a readable plain-text MIME body."""
+    if not html:
+        return ""
+    text = re.sub(r"(?i)<br\s*/?>", "\n", html)
+    text = re.sub(r"(?i)</p\s*>", "\n\n", text)
+    text = re.sub(r"(?i)</div\s*>", "\n", text)
+    text = re.sub(r"(?i)</li\s*>", "\n", text)
+    text = re.sub(r"(?i)</h[1-6]\s*>", "\n\n", text)
+    text = strip_tags(text)
+    text = unescape(text)
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
 
 
 def get_recipients(

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from django_scopes import scope, scopes_disabled
 from eventyay.base.email import SimpleFunctionalMailTextPlaceholder
 from eventyay.base.models.organizer import Team
-from eventyay.base.signals import register_mail_placeholders
+from eventyay.base.signals import email_filter, register_mail_placeholders
 from eventyay.common.signals import periodic_task, user_menu_items
 from eventyay.control.signals import event_dashboard_components, event_dashboard_widgets, nav_global
 from eventyay.multidomain.urlreverse import build_absolute_uri
@@ -19,6 +19,7 @@ from eventyay.presale.signals import header_nav_tabs
 
 from .models import ApplicationStatus, CallForTeamMembers, ShiftAssignment, TeamMemberApplication, TeamRole, TeamShiftsEmailQueue
 from .permissions import has_any_teamshifts_permission
+from .services.email import html_to_plain_text, looks_like_email_html
 from .tasks import send_queued_email
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,15 @@ def teamshifts_public_schedule_nav_tab(sender, request=None, **kwargs):
         "active" if is_active else "",
         _("Shift Schedule"),
     )
+
+
+@receiver(email_filter, dispatch_uid="teamshifts_email_plain_text_body")
+def teamshifts_email_plain_text_body(sender, message, order=None, user=None, **kwargs):
+    """Keep the text/plain MIME part free of raw Tiptap HTML tags (#116)."""
+    body = getattr(message, "body", None) or ""
+    if looks_like_email_html(body):
+        message.body = html_to_plain_text(body)
+    return message
 
 
 @receiver(register_mail_placeholders, dispatch_uid="teamshifts_mail_placeholders")

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -482,7 +482,7 @@ class EmailTemplatePreviewView(PluginActiveMixin, TeamShiftsPermissionRequiredMi
         from collections import defaultdict
 
         from eventyay.base.i18n import language
-        from eventyay.base.templatetags.rich_text import markdown_compile_email
+        from eventyay.base.templatetags.rich_text import compile_email_body
 
         event = request.event
         event_locales = list(event.settings.locales)
@@ -508,7 +508,7 @@ class EmailTemplatePreviewView(PluginActiveMixin, TeamShiftsPermissionRequiredMi
                 lambda m: f'<span class="placeholder">{escape(sample_values.get(m.group(1), m.group(0)))}</span>',
                 text,
             )
-            return markdown_compile_email(highlighted)
+            return compile_email_body(highlighted)
 
         body_values = request.POST.getlist("body")
         previews = {}

--- a/tests/test_email_html_rendering.py
+++ b/tests/test_email_html_rendering.py
@@ -19,7 +19,6 @@ from teamshifts.services.email import html_to_plain_text, looks_like_email_html,
 from teamshifts.signals import teamshifts_email_plain_text_body
 from teamshifts.tasks import send_queued_email
 
-
 TIPTAP_BODY = (
     "<p>Hi {full_name},</p>"
     "<p>Thank you for your interest in joining the {event_name} team.</p>"
@@ -86,6 +85,13 @@ def test_html_to_plain_text_preserves_paragraphs_without_tags():
     assert "\n" in plain
 
 
+def test_looks_like_email_html_detects_headings_only():
+    """Issue #116 regresion: a body containing only heading tags must be
+    detected as HTML so the plain-text MIME part is stripped."""
+    assert looks_like_email_html("<h1>Title</h1><h2>Subtitle</h2>") is True
+    assert "<p>" not in html_to_plain_text("<h1>Title</h1><h2>Subtitle</h2>")
+
+
 def test_sanitize_i18n_email_html_strips_unsafe_tags():
     dirty = LazyI18nString({"en": '<p>Hello</p><script>alert(1)</script><p onclick="x">World</p>'})
     cleaned = sanitize_i18n_email_html(dirty)
@@ -142,7 +148,7 @@ def test_email_compose_form_uses_sanitizing_body_field(event):
     locales = list(event.settings.locales) or ["en"]
     form = EmailComposeForm(
         data={
-            **_i18n_post(locales, subject="Hello", message='<p>Hi</p><script>alert(1)</script>'),
+            **_i18n_post(locales, subject="Hello", message="<p>Hi</p><script>alert(1)</script>"),
             "status": ApplicationStatus.ACCEPTED,
         },
         event=event,

--- a/tests/test_email_html_rendering.py
+++ b/tests/test_email_html_rendering.py
@@ -1,0 +1,222 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django_scopes import scope
+from i18nfield.strings import LazyI18nString
+
+from teamshifts.forms import EmailComposeForm, EmailTemplateForm, sanitize_i18n_email_html
+from teamshifts.models import (
+    ApplicationStatus,
+    CallForTeamMembers,
+    EmailTemplateRoles,
+    TeamMemberApplication,
+    TeamRole,
+    TeamShiftsEmailQueueRecipient,
+    TeamShiftsEmailTemplate,
+)
+from teamshifts.services.email import html_to_plain_text, looks_like_email_html, queue_lifecycle_email
+from teamshifts.signals import teamshifts_email_plain_text_body
+from teamshifts.tasks import send_queued_email
+
+
+TIPTAP_BODY = (
+    "<p>Hi {full_name},</p>"
+    "<p>Thank you for your interest in joining the {event_name} team.</p>"
+    "<p></p>"
+    "<p>Unfortunately, we are unable to accept your application at this time.</p>"
+    "<p>We appreciate your enthusiasm and hope you enjoy the event.</p>"
+    "<p>Best regards,</p>"
+    "<p>The {event_name} team</p>"
+)
+
+
+@pytest.fixture
+def call_for_team_members(event):
+    with scope(event=event):
+        return CallForTeamMembers.objects.create(event=event, active=True)
+
+
+@pytest.fixture
+def role(event):
+    with scope(event=event):
+        return TeamRole.objects.create(event=event, name="Volunteer")
+
+
+@pytest.fixture
+def applicant(event, role, django_user_model):
+    user = django_user_model.objects.create_user(
+        email="velia@example.com",
+        password="x",
+        fullname="Velia",
+        locale="en",
+    )
+    with scope(event=event):
+        TeamMemberApplication.objects.create(
+            event=event,
+            user=user,
+            status=ApplicationStatus.PENDING,
+        )
+    return user
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", False),
+        ("Hi there", False),
+        ("Hello <b>world</b>", True),
+        ("<p>Hello</p>", True),
+        ("3 < 4 and 5 > 2", False),
+    ],
+)
+def test_looks_like_email_html(value, expected):
+    assert looks_like_email_html(value) is expected
+
+
+def test_html_to_plain_text_preserves_paragraphs_without_tags():
+    plain = html_to_plain_text(TIPTAP_BODY)
+    assert "<p>" not in plain
+    assert "</p>" not in plain
+    assert "&lt;" not in plain
+    assert "Hi {full_name}," in plain
+    assert "Thank you for your interest" in plain
+    assert "Best regards," in plain
+    # Paragraph boundaries should not collapse into a single line.
+    assert "\n" in plain
+
+
+def test_sanitize_i18n_email_html_strips_unsafe_tags():
+    dirty = LazyI18nString({"en": '<p>Hello</p><script>alert(1)</script><p onclick="x">World</p>'})
+    cleaned = sanitize_i18n_email_html(dirty)
+    text = str(cleaned)
+    assert "<script>" not in text
+    assert "onclick" not in text
+    assert "Hello" in text
+    assert "World" in text
+
+
+def _i18n_post(locales, **fields_by_name):
+    """Build POST data for i18nfield widgets (name_0, name_1, … per locale order)."""
+    data = {}
+    for name, value in fields_by_name.items():
+        for index, _locale in enumerate(locales):
+            data[f"{name}_{index}"] = value
+    return data
+
+
+@pytest.mark.django_db
+def test_email_template_form_sanitizes_tiptap_html_on_save(event, call_for_team_members):
+    locales = list(event.settings.locales) or ["en"]
+    locale = locales[0]
+    with scope(event=event):
+        template = TeamShiftsEmailTemplate.objects.create(
+            event=event,
+            role=EmailTemplateRoles.APPLICATION_REJECTED,
+            subject=LazyI18nString({locale: "Update"}),
+            body=LazyI18nString({locale: "plain"}),
+        )
+
+    form = EmailTemplateForm(
+        data=_i18n_post(
+            locales,
+            subject="Update on your application",
+            body=TIPTAP_BODY + '<script>alert("x")</script>',
+        ),
+        instance=template,
+        locales=locales,
+    )
+    assert form.is_valid(), form.errors
+    with scope(event=event):
+        saved = form.save()
+        saved.refresh_from_db()
+        body = str(saved.body)
+
+    assert "<p>Hi {full_name},</p>" in body
+    assert "<script>" not in body
+    assert "alert" not in body
+
+
+@pytest.mark.django_db
+def test_email_compose_form_uses_sanitizing_body_field(event):
+    locales = list(event.settings.locales) or ["en"]
+    form = EmailComposeForm(
+        data={
+            **_i18n_post(locales, subject="Hello", message='<p>Hi</p><script>alert(1)</script>'),
+            "status": ApplicationStatus.ACCEPTED,
+        },
+        event=event,
+    )
+    assert form.is_valid(), form.errors
+    message = str(form.cleaned_data["message"])
+    assert "<p>Hi</p>" in message
+    assert "<script>" not in message
+
+
+def test_email_filter_strips_html_from_plain_mime_part():
+    raw_html = TIPTAP_BODY.replace("{full_name}", "Velia").replace("{event_name}", "Summit")
+    message = SimpleNamespace(body=raw_html)
+
+    filtered = teamshifts_email_plain_text_body(sender=None, message=message)
+
+    assert filtered is message
+    assert filtered.body == html_to_plain_text(raw_html)
+    assert "<p>" not in filtered.body
+    assert "Hi Velia," in filtered.body
+    assert "Best regards," in filtered.body
+
+
+@pytest.mark.django_db
+def test_lifecycle_email_with_tiptap_template_renders_html_and_plain(event, call_for_team_members, applicant, role):
+    """Regression for #116: edited Tiptap HTML templates must not leak raw tags."""
+    locales = list(event.settings.locales) or ["en"]
+    locale = locales[0]
+    with scope(event=event):
+        TeamShiftsEmailTemplate.objects.update_or_create(
+            event=event,
+            role=EmailTemplateRoles.APPLICATION_REJECTED,
+            defaults={
+                "subject": LazyI18nString({locale: "Update on your application"}),
+                "body": LazyI18nString({locale: TIPTAP_BODY}),
+            },
+        )
+        application = TeamMemberApplication.objects.get(user=applicant)
+
+    # Queue without dispatching so we can assert on the stored template and
+    # control the send path (eager Celery would otherwise send immediately).
+    with patch("teamshifts.services.email._dispatch"):
+        queue = queue_lifecycle_email(application, EmailTemplateRoles.APPLICATION_REJECTED)
+
+    assert queue is not None
+    with scope(event=event):
+        queue.refresh_from_db()
+        stored = str(queue.message)
+    assert "<p>Hi {full_name},</p>" in stored
+
+    plain = html_to_plain_text(
+        stored.replace("{full_name}", "Velia").replace("{event_name}", str(event.name)),
+    )
+    assert "<p>" not in plain
+    assert "</p>" not in plain
+    assert "Hi Velia," in plain
+    assert "Unfortunately, we are unable to accept" in plain
+
+    with patch("teamshifts.tasks.mail") as mock_mail:
+        send_queued_email.run(event_id=event.pk, queue_id=queue.pk)
+
+    mock_mail.assert_called_once()
+    kwargs = mock_mail.call_args.kwargs
+    sent_template = str(kwargs["template"])
+    assert "<p>Hi {full_name},</p>" in sent_template
+    assert "&lt;p&gt;" not in sent_template
+
+    # Plain MIME conversion used by email_filter must not leave tags.
+    filtered_body = html_to_plain_text(sent_template.format(full_name="Velia", event_name=str(event.name), role_name="Volunteer"))
+    assert "<p>" not in filtered_body
+    assert "Hi Velia," in filtered_body
+
+    with scope(event=event):
+        queue.refresh_from_db()
+        recipient = TeamShiftsEmailQueueRecipient.objects.get(queue=queue)
+    assert queue.sent_at is not None
+    assert recipient.sent_at is not None


### PR DESCRIPTION
## Problem
After editing an email template using the rich-text (Tiptap) editor, newly sent emails showed raw HTML tags instead of formatted text, and line breaks between paragraphs were lost. 

## Root cause
- Default templates are plain text, so the host's `compile_email_body()` runs them through Markdown into real `<p>` HTML this is why unedited templates rendered correctly.
- Once a template is edited via the Tiptap editor, it's saved as real HTML (`<p>...</p>`), but:
  - The template/compose forms weren't sanitizing that HTML the way the existing "Message center" pattern does elsewhere in the host app.
  - The preview view was compiling with `markdown_compile_email` instead of `compile_email_body`, so it didn't handle Tiptap HTML correctly.
  - The `text/plain` MIME part sent by `mail()` contained the raw HTML string unchanged, so plain-text-preferring clients (or any fallback to the plain part) showed literal `<p>` tags.

## Fix
- `forms.py`: switch `EmailTemplateForm`, `CustomEmailTemplateForm`,
  `EmailComposeForm`, and `EmailQueueEditForm` to use
  `I18nEmailBodyFormField`, and sanitize saved HTML via
  `sanitize_email_html` in each form's `clean_body`/`clean_message`,
  matching the existing Message center pattern.
- `views.py`: preview now compiles with `compile_email_body` instead of
  `markdown_compile_email`.
- `services/email.py`: adds `looks_like_email_html()` and
  `html_to_plain_text()` helpers to detect HTML content and convert it into
  readable plain text (real newlines instead of tags).
- `signals.py`: new `email_filter` receiver strips HTML from the
  `text/plain` MIME part before send, using the helpers above, so clients
  never see raw tags even as a fallback.
- `tests/test_email_html_rendering.py`: regression coverage for the HTML
  sanitization, preview compilation, and plain-text fallback conversion.

## Testing
Ran the full email-related test suite in a CI-matched environment (cloned `eventyay`, `uv sync`, editable plugin install, local Postgres 15 + Redis):   
tests/test_email_html_rendering.py ............. (10)
tests/test_email_service.py ........ (9)
tests/test_email_tasks.py ...... (7)
======================= 26 passed, 5 warnings in 29.11s ========================


Also manually verified the HTML-detection regex against edge cases (plain text with `<`/`>` characters doesn't falsely trigger) and confirmed the form's `initial` loading path doesn't double-escape existing template content.

Fixes #116

## Summary by Sourcery

Ensure rich-text email templates render safely and consistently in previews and both HTML and plain-text messages.

Bug Fixes:
- Prevent raw Tiptap HTML from appearing in sent email plain-text content and preserve paragraph line breaks for fallback email clients.
- Correct email previews so edited rich-text templates render as HTML rather than being treated as Markdown.

Enhancements:
- Apply consistent email-body field handling and sanitization across templates, composition, and queued-email editing forms.
- Add shared detection and conversion support for turning email HTML into readable plain text.

Tests:
- Add regression coverage for HTML sanitization, preview rendering, HTML detection, plain-text conversion, MIME filtering, and lifecycle email delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for safely sanitizing localized HTML email content.
  - Improved email previews and delivery by converting HTML-formatted messages into readable plain text where appropriate.
  - Enhanced recognition of formatted email content, including heading-based layouts.
  - Preserved formatted content through template storage, queuing, and sending workflows.

- **Bug Fixes**
  - Improved placeholder rendering in email template previews.
  - Prevented HTML markup from appearing in plain-text email outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->