### PR TITLE
Fix application form question redirect

### DIFF
--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -605,7 +605,7 @@ class QuestionEditView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, Vie
                 messages.success(request, _("Question '%s' added.") % saved.question)
             else:
                 messages.success(request, _("Question saved."))
-            return redirect("plugins:teamshifts:cfm_settings", organizer=request.organizer.slug, event=request.event.slug)
+            return redirect("plugins:teamshifts:cfm_application_form", organizer=request.organizer.slug, event=request.event.slug)
         return render(request, self.template_name, {"form": form, "question": instance})
 
 
@@ -626,7 +626,7 @@ class QuestionDeleteView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, V
             except CallForTeamMembers.DoesNotExist:
                 pass
         messages.success(request, _("Question '%s' deleted.") % label)
-        return redirect("plugins:teamshifts:cfm_settings", organizer=request.organizer.slug, event=event.slug)
+        return redirect("plugins:teamshifts:cfm_application_form", organizer=request.organizer.slug, event=event.slug)
 
 
 class QuestionReorderView(PluginActiveMixin, TeamShiftsPermissionRequiredMixin, View):


### PR DESCRIPTION
Changed QuestionEditView and QuestionDeleteView redirects from cfm_settings to cfm_application_form.
Closes #139

https://github.com/user-attachments/assets/70913900-7501-4486-9ca9-a8aea2cb55b3

## Summary by Sourcery

Bug Fixes:
- Redirect question editing and deletion back to the application form page instead of the general settings page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - After saving or deleting a question, users are now redirected to the application form page instead of the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->