### PR TITLE
fix: apply selected text color in certificate preview and download

### DIFF
--- a/teamshifts/pdf.py
+++ b/teamshifts/pdf.py
@@ -40,11 +40,6 @@ CERTIFICATE_PLACEHOLDERS = (
 CERTIFICATE_DEFAULT_STATIC = "teamshifts/certificates/certificate_default.pdf"
 
 
-def hex_to_rgba(hex_color: str) -> list:
-    hex_color = hex_color.lstrip("#")
-    return [int(hex_color[i : i + 2], 16) for i in (0, 2, 4)] + [1]
-
-
 NAVY = [27, 54, 93, 1]
 
 DEFAULT_CERTIFICATE_LAYOUT = [
@@ -169,7 +164,6 @@ def preview_context(event):
     from django.utils.translation import gettext
 
     location = str(event.location) if event.location else "Berlin, Germany"
-    event_color = event.visible_primary_color or "#c0392b"
     return {
         "certificate_title": gettext("Certificate of Appreciation"),
         "certificate_intro": gettext("presents this"),
@@ -193,7 +187,6 @@ def preview_context(event):
         "assigned_shift_count": "3",
         "roles": "Registration, Info desk",
         "issued_date": gettext("Date Issued: %(date)s") % {"date": "24 August 2026"},
-        "_event_color": event_color,
     }
 
 
@@ -338,13 +331,6 @@ class CertificateRenderer(Renderer):
         )
 
     def draw_page(self, canvas: Canvas, order=None, op=None, show_page=True):
-        event_color = self.context.get("_event_color")
-        if event_color:
-            color_rgba = hex_to_rgba(event_color)
-            for obj in self.layout:
-                if obj.get("type") == "textarea" and obj.get("content") in ("certificate_title", "member_name"):
-                    obj["color"] = color_rgba
-
         allowed = {"textarea", "poweredby", "imagearea"}
         layout = [obj for obj in self.layout if obj.get("type") in allowed]
         original = self.layout

--- a/teamshifts/services/certificates.py
+++ b/teamshifts/services/certificates.py
@@ -65,7 +65,6 @@ def application_context(application: TeamMemberApplication) -> dict:
     location = str(event.location) if event.location else ""
     date_from = format_event_date_from(event)
     date_to = format_event_date_to(event)
-    event_color = event.visible_primary_color or "#c0392b"
     issued = now()
 
     body_line2 = gettext("the %(event_name)s, held from %(date_from)s to %(date_to)s, in %(location)s.") % {
@@ -92,7 +91,6 @@ def application_context(application: TeamMemberApplication) -> dict:
         "assigned_shift_count": str(len(assignments)),
         "roles": ", ".join(roles),
         "issued_date": gettext("Date Issued: %(date)s") % {"date": date_format(issued, "DATE_FORMAT")},
-        "_event_color": event_color,
     }
 
 


### PR DESCRIPTION
Fixes #145

### Description
When changing the text color in the certificate layout editor, the selected color is correctly saved in the layout settings. However, during PDF generation (for both preview and download), `CertificateRenderer.draw_page` was explicitly overriding the color of `certificate_title` and `member_name` with `_event_color`, causing the text to revert to the default color.

### Changes
* Removed the `_event_color` color override in `CertificateRenderer.draw_page` in `teamshifts/pdf.py`.
* Removed unused `_event_color` context injection in `preview_context` (`teamshifts/pdf.py`) and `application_context` (`teamshifts/services/certificates.py`).
* Cleaned up the now unused `hex_to_rgba` helper in `teamshifts/pdf.py`.


https://github.com/user-attachments/assets/1ef85568-8f21-4eec-90e2-f9234cdbe46c



## Summary by Sourcery

Apply saved certificate layout text colors consistently across preview and PDF generation.

Bug Fixes:
- Preserve the selected certificate text color when generating certificate previews and downloaded PDFs.

Enhancements:
- Remove obsolete event-color context handling and the unused color-conversion helper from certificate rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Certificate titles and member names no longer change text color based on an event’s primary color.
  - Certificate previews no longer apply event-specific color overrides, providing consistent text styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->