### PR TITLE
fix: hide My Shifts from admin sidebar

### DIFF
--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -182,6 +182,8 @@ def teamshifts_user_menu_item(sender, request=None, icon_class="", **kwargs):
 def teamshifts_nav_global_my_shifts(sender, request=None, **kwargs):
     if request is None or not getattr(request, "user", None) or not request.user.is_authenticated:
         return []
+    if "eventyay_admin" in getattr(getattr(request, "resolver_match", None), "namespaces", []):
+        return []
     with scopes_disabled():
         if not _has_shifts_in_active_events(request.user):
             return []


### PR DESCRIPTION
Closes fossasia/eventyay#5556

**Root cause:** `get_admin_navigation()` in `eventyay/control/navigation.py` calls `nav_global.send(request)` — the same signal our receiver connects to — so the "My Shifts" item was appearing in both the common dashboard sidebar AND the admin sidebar. The fix checks `request.resolver_match.namespaces` for `"eventyay_admin"` and returns an empty list if so. The admin sidebar is not the right place for a personal user schedule — it's a platform admin area.


https://github.com/user-attachments/assets/309913a6-539d-4dcb-a1c5-19baef3206b6

## Summary by Sourcery

Bug Fixes:
- Prevent the My Shifts navigation item from appearing in the eventyay admin sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “My Shifts” navigation entry is now hidden within the admin area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->